### PR TITLE
Correct property check for bitrate property in `resolveOptions`

### DIFF
--- a/lib/audioconv.js
+++ b/lib/audioconv.js
@@ -111,7 +111,7 @@ function resolveOptions(options) {
     format: (typeof options?.format === 'string')
       ? options.format
       : defaultOptions.format,
-    bitrate: ['string', 'number'].includes(typeof options?.format)
+    bitrate: ['string', 'number'].includes(typeof options?.bitrate)
       ? options.bitrate
       : defaultOptions.bitrate,
     frequency: (typeof options?.frequency === 'number')


### PR DESCRIPTION
Corrected the property check for bitrate in the `resolveOptions` function. Previously, the check was incorrectly applied to the format property instead of the bitrate property.