### PR TITLE
Switch YouTube downloader core module

### DIFF
--- a/lib/ytmp3.js
+++ b/lib/ytmp3.js
@@ -2,7 +2,7 @@
  * @file Core library for **YTMP3** project.
  *
  * This module contains the core functionality for **YTMP3** project.
- * It utilizes the [ytdl-core](https://www.npmjs.com/package/ytdl-core) (to download YouTube videos) and
+ * It utilizes the [@distube/ytdl-core](https://www.npmjs.com/package/@distube/ytdl-core) (to download YouTube videos) and
  * [fluent-ffmpeg](https://www.npmjs.com/package/fluent-ffmpeg) (to convert audio formats) libraries.
  *
  * This module provides APIs to easily download YouTube videos (also supports YouTube Music) and convert them to MP3 format.
@@ -44,7 +44,7 @@
 const fs = require('fs'),           // File system module
       os = require('os'),           // OS module
       path = require('path'),       // Path module
-      ytdl = require('ytdl-core');  // Youtube Downloader module
+      ytdl = require('@distube/ytdl-core');  // Youtube Downloader module
 
 const {
   // eslint-disable-next-line no-unused-vars

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0-beta",
       "license": "MIT",
       "dependencies": {
+        "@distube/ytdl-core": "^4.13.5",
         "argparse": "^2.0.1",
-        "fluent-ffmpeg": "^2.1.3",
-        "ytdl-core": "^4.11.5"
+        "fluent-ffmpeg": "^2.1.3"
       },
       "bin": {
         "ytmp3": "index.js"
@@ -44,6 +44,25 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@distube/ytdl-core": {
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/@distube/ytdl-core/-/ytdl-core-4.13.5.tgz",
+      "integrity": "sha512-g+4UJIR/auAJbia7iB0aWvaJDbs22P53NySWa47b1NT4xMTDJYguxHFArPrvRkcJrb/AgKjv/XoSZGghpL0CJA==",
+      "dependencies": {
+        "http-cookie-agent": "^6.0.5",
+        "m3u8stream": "^0.8.6",
+        "miniget": "^4.2.3",
+        "sax": "^1.4.1",
+        "tough-cookie": "^4.1.4",
+        "undici": "^6.19.2"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/distubejs/ytdl-core?sponsor"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -231,6 +250,17 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -397,7 +427,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -755,6 +784,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/http-cookie-agent": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-6.0.5.tgz",
+      "integrity": "sha512-sfZ8fDgDP3B1YB+teqSnAK1aPgBu8reUUGxSsndP2XnYN6cM29EURXWXZqQQiaRdor3B4QjpkUNfv21syaO4DA==",
+      "dependencies": {
+        "agent-base": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/3846masa"
+      },
+      "peerDependencies": {
+        "tough-cookie": "^4.0.0",
+        "undici": "^5.11.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "undici": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
@@ -1076,8 +1128,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -1189,11 +1240,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1206,6 +1261,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -1226,6 +1286,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/requizzle": {
       "version": "0.2.4",
@@ -1361,6 +1426,20 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -1397,6 +1476,22 @@
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
+    "node_modules/undici": {
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.2.tgz",
+      "integrity": "sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -1404,6 +1499,15 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/which": {
@@ -1439,19 +1543,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ytdl-core": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.5.tgz",
-      "integrity": "sha512-27LwsW4n4nyNviRCO1hmr8Wr5J1wLLMawHCQvH8Fk0hiRqrxuIu028WzbJetiYH28K8XDbeinYW4/wcHQD1EXA==",
-      "dependencies": {
-        "m3u8stream": "^0.8.6",
-        "miniget": "^4.2.2",
-        "sax": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=12"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "url": "https://ko-fi.com/dhefam31"
   },
   "dependencies": {
+    "@distube/ytdl-core": "^4.13.5",
     "argparse": "^2.0.1",
-    "fluent-ffmpeg": "^2.1.3",
-    "ytdl-core": "^4.11.5"
+    "fluent-ffmpeg": "^2.1.3"
   },
   "devDependencies": {
     "eslint": "^8.54.0",


### PR DESCRIPTION
## Overview

This pull request introduces an update to the YouTube core downloader module used in the project, replacing the deprecated [`ytdl-core`] module with the more current [`@distube/ytdl-core`] module. This change ensures compatibility with YouTube's updated algorithm for extracting the `N` parameter.

## Description

- **Switch the YouTube core downloader (32a8020)**
  - Removed the old `ytdl-core` module due to its deprecated extraction algorithm. YouTube has updated their algorithm, making the old module ineffective.
  - Added the new `@distube/ytdl-core` module, which offers updated download capabilities and compatibility with the new "N" extraction algorithm.

- **Change the import of core module (5cb8663)**
  - Updated the import statements in the `ytmp3` module to use the new `@distube/ytdl-core` module instead of the old `ytdl-core` module.

## Summary

These changes aim to maintain the functionality of the YouTube downloader by replacing the outdated `ytdl-core` module with the updated `@distube/ytdl-core` module, ensuring continued compatibility with YouTube's latest extraction algorithms. This update is crucial for the reliability and effectiveness of the YouTube download feature.


<!-- Links -->

[`ytdl-core`]: https://npmjs.com/package/ytdl-core
[`@distube/ytdl-core`]: https://npmjs.com/package/@distube/ytdl-core