### PR TITLE
Add support for multiple downloads with multiple URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ const __version__ = (() => {
   // eslint-disable-next-line prefer-const
   let [ ver, rel ] = (pkg.version || '0.0.0-dev').split('-');
   rel = (rel && rel.length !== 0)
-    ? rel.charAt(0).toUpperCase() + rel.substr(1)  // Capitalize first letter
+    ? rel.charAt(0).toUpperCase() + rel.substring(1)  // Capitalize first letter
     : 'Stable';
   return `\x1b[1m[${pkg.name.toUpperCase()}] v${ver} \x1b[2m${rel}\x1b[0m\n`;
 })();
@@ -254,9 +254,13 @@ async function filterOptions({ options }) {
   delete optionsCopy.quiet;
 
   // Extract and resolve the download options from configuration file if given
-  const dlOptionsFromConfig = optionsCopy.config
-    ? await /* may an ES module */ importConfig(optionsCopy.config)
+  let dlOptionsFromConfig = optionsCopy.config
+    ? importConfig(optionsCopy.config)
     : {};
+  // Await the download options if it is a promise
+  if (dlOptionsFromConfig instanceof Promise) {
+    dlOptionsFromConfig = await dlOptionsFromConfig;
+  }
   const acOptionsFromConfig = dlOptionsFromConfig.converterOptions || {};
   delete optionsCopy.config;  // No longer needed
   delete dlOptionsFromConfig.converterOptions;  // No longer needed

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@distube/ytdl-core": "^4.13.5",
+        "@mitsuki31/temppath": "^0.5.0",
         "argparse": "^2.0.1",
         "fluent-ffmpeg": "^2.1.3"
       },
@@ -164,6 +165,14 @@
       },
       "engines": {
         "node": ">=v12.0.0"
+      }
+    },
+    "node_modules/@mitsuki31/temppath": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@mitsuki31/temppath/-/temppath-0.5.0.tgz",
+      "integrity": "sha512-eu7p1aXAWfzRZRT/rLTrcuUWIUEr/FLi+kBNsHS6I77ivMoGI9th5ZOJehKWxhESAw8WLZr6X6NcKry4lOXSNw==",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@distube/ytdl-core": "^4.13.5",
+    "@mitsuki31/temppath": "^0.5.0",
     "argparse": "^2.0.1",
     "fluent-ffmpeg": "^2.1.3"
   },


### PR DESCRIPTION
## Overview

This pull request introduces significant enhancements to the project, including support for multiple downloads via command line arguments, cache management functionality, and various internal code improvements.

## Notable Changes

- Introduced the `temppath` module, developed in-house, which simplifies the creation of temporary directories or files. This module streamlines processes that require temporary storage, providing an uncomplicated and efficient solution.

- Implemented functionality allowing users to supply multiple YouTube URLs directly via command line arguments, eliminating the need for a temporary file containing URLs. This feature enhances flexibility and convenience for users who prefer CLI-based operations. For example:

  ```bash
  $ ytmp3 -o downloads --convertAudio --codec libmp3lame --format mp3 \
  > https://www.youtube.com/watch?v=<VIDEO_ID> https://www.youtube.com/watch?v=<VIDEO_ID>
  ```

  > This update resolves task in #11, which aimed to simplify the multi-download process.

- Replaced the deprecated `substr` function with `substring` to ensure compatibility with modern JavaScript standards and improve code readability.

## Summary

These updates significantly enhance the project's capabilities, particularly by adding support for multiple downloads. The introduction of the `temppath` module, along with the cache management functions for caching the given multiple URLs from command line, provides a more efficient and streamlined experience for users. Additionally, the internal code improvements ensure better maintainability and alignment with modern coding practices.