### PR TITLE
Fix error logging and directory creation

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -92,6 +92,17 @@ async function createDirIfNotExist(dirpath) {
 }
 
 /**
+ * Similar with {@link module:utils~createDirIfNotExist `createDirIfNotExist`}
+ * function, but it uses synchronous directory creation.
+ *
+ * @public
+ * @since 1.0.1
+ */
+function createDirIfNotExistSync(dirpath) {
+  if (!fs.existsSync(dirpath)) fs.mkdirSync(dirpath, { recursive: true });
+}
+
+/**
  * **Logger Namespace**
  * @namespace module:utils~Logger
  * @public
@@ -393,5 +404,6 @@ module.exports = Object.freeze({
   isObject,
   ProgressBar,
   createDirIfNotExist,
+  createDirIfNotExistSync,
   dropNullAndUndefined
 });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -88,7 +88,7 @@ const LOGDIR = path.join(os.homedir(), '.ytmp3-js', 'logs');
  * @since  1.0.0
  */
 async function createDirIfNotExist(dirpath) {
-  if (!fs.existsSync(dirpath)) await fs.promises.mkdir(dirpath);
+  if (!fs.existsSync(dirpath)) await fs.promises.mkdir(dirpath, { recursive: true });
 }
 
 /**

--- a/lib/ytmp3.js
+++ b/lib/ytmp3.js
@@ -55,7 +55,8 @@ const {
   LOGDIR,
   logger: log,
   ProgressBar,
-  createDirIfNotExist
+  createDirIfNotExist,
+  createDirIfNotExistSync
 } = require('./utils');
 const {
   checkFfmpeg,
@@ -368,11 +369,11 @@ async function getVideosInfo(...urls) {
  * @private
  * @since  1.0.0
  */
-async function writeLogError(logfile, videoData, error) {
+function writeLogError(logfile, videoData, error) {
   if (!logfile || typeof logfile !== 'string') return;
 
   logfile = path.join(LOGDIR, path.basename(logfile));
-  await createDirIfNotExist(LOGDIR);
+  createDirIfNotExistSync(LOGDIR);
 
   const logStream = fs.createWriteStream(logfile, { flags: 'a+', flush: true });
 
@@ -476,13 +477,13 @@ async function downloadHandler(readable, data, verbose=false) {
         verbose && log.done(`Download finished: \x1b[93m${data.videoData.title}\x1b[0m`);
         resolve();
       })
-      .on('error', async (err) => {
+      .on('error', (err) => {
         verbose && log.error(`Download failed: ${data.videoData.title}`);
 
         // Close the output stream if it's still open
         data.outStream.closed || data.outStream.close();
 
-        await writeLogError(data.errLogFile, data.videoData, err);
+        writeLogError(data.errLogFile, data.videoData, err);
         reject(err);
       })
       .pipe(data.outStream);


### PR DESCRIPTION
## Notable Changes

* Added a new function called `createDirIfNotExistSync` function in `utils` module
* Refactored `writeLogError` to be synchronous, ensuring the error log directory is created synchronously before writing logs.
* Replaced `createDirIfNotExist` with `createDirIfNotExistSync` for synchronous directory creation in `writeLogError`.
* Removed unnecessary async/await from the `writeLogError` call within the `downloadHandler` function to streamline error logging.
* Enhanced the `createDirIfNotExist` function to ensure that directories are created recursively if they do not exist. This change prevents errors when the specified path contains intermediate directories that do not exist.
* Updated the function call to `fs.promises.mkdir` to include the `{ recursive: true }` option, ensuring the entire directory path is created without error.
  ```diff
  - if (fs.existsSync(dirpath)) await fs.promises.mkdir(dirpath);
  + if (fs.existsSync(dirpath)) await fs.promises.mkdir(dirpath, { recursive: true });
  ```

## Impacts

* Ensures robust error log directory creation even if parent directories do not exist.
* Prevents potential issues during log directory creation, enhancing the stability of the logging mechanism.
* Ensures the log directory is created synchronously, reducing the chance of missing logs due to asynchronous directory creation.