### PR TITLE
Update and change the version in `ytmp3` module dynamically

### DIFF
--- a/lib/ytmp3.js
+++ b/lib/ytmp3.js
@@ -122,7 +122,7 @@ const { VIDEO: VIDEO_URL } = require('./yt-urlfmt');
  * @default
  * @public
  */
-const VERSION = '1.0.0';
+const VERSION = require('../package.json').version;
 
 // Prevent the 'ytdl-core' module to check updates
 Object.assign(process.env, { YTDL_NO_UPDATE: true });


### PR DESCRIPTION
## Overview

Instead using a constant value that needs to be changed when release, we change it to use dynamic method which retrieve the version information from `package.json` file.

This also addressed the issue with versions 1.0.1 and 1.0.2, where the version in `ytmp3` module was not altered and remained at 1.0.0.

## Testing

You can compare both value of version from the `ytmp3` module and `package.json` file.
```bash
node -p "require('ytmp3-js').version" && node -p "require('ytmp3-js/package.json').version"
```