### PR TITLE
Enhance CLI with custom FFmpeg I/O options and improved logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,6 +138,36 @@ function initParser() {
   });
 
   // ==== Audio Converter Options ==== //
+  // :: inputOptions
+  parser.add_argument(
+    '--inputOptions',
+    '--input-options',
+    '--addInputOptions',
+    '--add-input-options',
+    '--inOpt',
+    {
+      metavar: 'OPT',
+      help: 'Add custom input options for audio conversion',
+      type: 'str',
+      dest: 'inputOptions',
+    }
+  );
+  // :: outputOptions
+  parser.add_argument(
+    '--outputOptions',
+    '--output-options',
+    '--addOption',
+    '--add-option',
+    '--addOutputOptions',
+    '--add-output-options',
+    '--outOpt',
+    {
+      metavar: 'OPT',
+      help: 'Add custom output options for audio conversion',
+      type: 'str',
+      dest: 'outputOptions',
+    }
+  );
   // :: format
   parser.add_argument('--format', {
     metavar: 'FMT',

--- a/lib/audioconv.js
+++ b/lib/audioconv.js
@@ -29,14 +29,21 @@
 
 const fs = require('fs');
 const path = require('path');
-const { promisify } = require('node:util');
 const childProcess = require('node:child_process');
+const { EOL } = require('node:os');
+const { promisify } = require('node:util');
 const ffmpeg = require('fluent-ffmpeg');
 
+const {
+  logger: log,
+  LOGDIR,
+  isNullOrUndefined,
+  createDirIfNotExistSync,
+  createLogFile,
+} = require('./utils');
 // Promisify the `exec` function
 const spawn = promisify(childProcess.exec);
 
-const { logger: log } = require('./utils');
 
 /**
  * Options for configuring the audio conversion.
@@ -183,6 +190,25 @@ async function checkFfmpeg(verbose=false) {
   }
 }
 
+function writeErrorLog(logFile, data, error) {
+  // Throw the error if the log file name is invalid
+  if (isNullOrUndefined(logFile) || typeof logFile !== 'string') {
+    throw error;
+  }
+
+  logFile = path.join(LOGDIR, path.basename(logFile));
+  createDirIfNotExistSync(LOGDIR);
+
+  const logStream = fs.createWriteStream(logFile);
+
+  logStream.write(`[ERROR]<ACONV> ${error?.message || 'Unknown error'}${EOL}`);
+  logStream.write(`   Input Audio: ${data?.inputAudio || 'Unknown'}${EOL}`);
+  logStream.write(`   Output Audio: ${data?.outputAudio || 'Unknown'}${EOL}`);
+  logStream.write(`   File Size: ${data?.inputSize / (1024 * 1024) || '0.0'} MiB${EOL}`);
+  logStream.write(`---------------------------------------------${EOL}`);
+  logStream.end(EOL);
+}
+
 
 function createConversionProgress(info, extnames) {
   const percentage = Math.max(0, Math.round(info.percent || 0));
@@ -284,6 +310,11 @@ async function convertAudio(inFile, options = defaultOptions) {
       .on('error', (err) => {
         if (!quiet) {
           process.stdout.write('\n');
+          writeErrorLog(createLogFile('audioConvError'), {
+            inputFile: inFile,
+            outputFile: outFile,
+            inputSize: fs.statSync(inFile).size
+          }, err);
           log.error('Failed to convert the audio file');
           console.error('Caused by:', err.message);
         }
@@ -293,12 +324,12 @@ async function convertAudio(inFile, options = defaultOptions) {
         // Write the progress information to the console
         quiet || process.stdout.write(createConversionProgress(info, extnames));
       })
-      .on('end', async () => {
+      .on('end', () => {
         quiet || process.stdout.write('\n');
 
         // Remove the old audio file if `deleteOld` option is true
         if (options.deleteOld) {
-          await fs.promises.rm(inFile);
+          fs.rmSync(inFile);
         }
         resolve();
       })

--- a/lib/audioconv.js
+++ b/lib/audioconv.js
@@ -216,7 +216,7 @@ function resolveOptions(options, useDefault=true) {
  */
 async function checkFfmpeg(verbose=false) {
   verbose && log.debug('Checking `ffmpeg` binary...');
-  if (process.env.FFMPEG_PATH) {
+  if (process.env.FFMPEG_PATH || process.env.FFMPEG_PATH !== '') {
     if ((await fs.promises.stat(process.env.FFMPEG_PATH)).isDirectory()) {
       const msg = '[EISDIR] Please set the FFMPEG_PATH environment variable '
         + 'to the path of the `ffmpeg` binary';

--- a/lib/audioconv.js
+++ b/lib/audioconv.js
@@ -37,18 +37,22 @@ const ffmpeg = require('fluent-ffmpeg');
 const {
   logger: log,
   LOGDIR,
-  isNullOrUndefined,
   createDirIfNotExistSync,
   createLogFile,
+  dropNullAndUndefined,
+  isNullOrUndefined
 } = require('./utils');
+
 // Promisify the `exec` function
-const spawn = promisify(childProcess.exec);
+const exec = promisify(childProcess.exec);
 
 
 /**
  * Options for configuring the audio conversion.
  *
  * @typedef  {Object} ConvertAudioOptions
+ * @property {string[]} [inputOptions] - The input options for the conversion.
+ * @property {string[]} [outputOptions] - The output options for the conversion.
  * @property {string} [format='mp3'] - The desired output format (e.g., `'mp3'`, `'aac'`).
  * @property {string | number} [bitrate=128] - The audio bitrate (e.g., `'128k'`),
  *                                               it may be a number or a string with an optional `k` suffix.
@@ -66,7 +70,9 @@ const spawn = promisify(childProcess.exec);
 /**
  * The resolved {@link module:audioconv~ConvertAudioOptions ConvertAudioOptions} options.
  *
- * @typedef  {ConvertAudioOptions} ResolvedConvertAudioOptions
+ * @typedef  {Object} ResolvedConvertAudioOptions
+ * @property {string[]} inputOptions - The input options for the conversion.
+ * @property {string[]} outputOptions - The output options for the conversion.
  * @property {string} format - The desired output format (e.g., `'mp3'`, `'aac'`).
  * @property {string | number} bitrate - The audio bitrate (e.g., `'128k'`),
  *                                               it may be a number or a string with an optional `k` suffix.
@@ -97,6 +103,8 @@ const spawn = promisify(childProcess.exec);
  * @since   0.2.0
  */
 const defaultOptions = Object.freeze({
+  inputOptions: [],
+  outputOptions: [],
   format: 'mp3',
   bitrate: 128,  // optional `k` suffix
   frequency: 44100,
@@ -105,6 +113,44 @@ const defaultOptions = Object.freeze({
   deleteOld: false,
   quiet: false
 });
+
+// region Utilities
+
+function splitOptions(options) {
+  if (typeof options === 'string') {
+    const optionsList = options.trim().split(' ');
+    const resolvedOptions = [];
+
+    // Iterate over the options and resolve the option
+    optionsList.forEach((option, index) => {
+      let valueIndex = -1;  // To indicate if the option has a value, -1 means no value
+
+      // Only resolve the option that starts with a hyphen ('-')
+      if (option.startsWith('-')) {
+        valueIndex = index + 1;
+        if (valueIndex < optionsList.length) {
+          resolvedOptions.push(`${option} ${optionsList[valueIndex]}`);
+        } else {
+          resolvedOptions.push(option);
+        }
+      } else {
+        // If the option doesn't start with a hyphen, it's a value
+        // of the previous option and won't add it to the list
+        // and also this option may an invalid or unknown option for FFmpeg
+        if (valueIndex > -1) resolvedOptions.push(option);
+      }
+    });
+
+    // Drop null and undefined values and convert to an array
+    return Object.values(dropNullAndUndefined(
+      resolvedOptions.map(option => option.trim())
+    ));
+  } else if (Array.isArray(options)) {
+    return options;
+  }
+
+  return [];
+}
 
 /**
  * Resolves the given {@link ConvertAudioOptions} options.
@@ -116,6 +162,20 @@ const defaultOptions = Object.freeze({
  */
 function resolveOptions(options, useDefault=true) {
   return {
+    inputOptions: (
+      Array.isArray(options?.inputOptions)
+        ? options.inputOptions
+        : (typeof options?.inputOptions === 'string')
+          ? splitOptions(options.inputOptions)
+          : (useDefault ? defaultOptions.inputOptions : undefined)
+    ),
+    outputOptions: (
+      Array.isArray(options?.outputOptions)
+        ? options.outputOptions
+        : (typeof options?.outputOptions === 'string')
+          ? splitOptions(options.outputOptions)
+          : (useDefault ? defaultOptions.outputOptions : undefined)
+    ),
     format: (typeof options?.format === 'string')
       ? options.format
       : (useDefault ? defaultOptions.format : undefined),
@@ -171,7 +231,7 @@ async function checkFfmpeg(verbose=false) {
   // This try-catch block to handle error,
   // in case the `ffmpeg` binary is not installed on system
   try {
-    const { status } = await spawn('ffmpeg -version', { shell: true });
+    const { status } = await exec('ffmpeg -version');
     if (status !== 0) {
       verbose && log.debug('`ffmpeg` installed on system');
       return true;
@@ -208,6 +268,9 @@ function writeErrorLog(logFile, data, error) {
   logStream.write(`---------------------------------------------${EOL}`);
   logStream.end(EOL);
 }
+
+
+// region Audio Conversion
 
 
 function createConversionProgress(info, extnames) {
@@ -252,6 +315,8 @@ function createConversionProgress(info, extnames) {
  */
 async function convertAudio(inFile, options = defaultOptions) {
   inFile = path.resolve(inFile);
+  options = dropNullAndUndefined(options);  // Drop all nullable properties
+
   /**
    * @ignore
    * @type {ResolvedConvertAudioOptions}
@@ -264,28 +329,41 @@ async function convertAudio(inFile, options = defaultOptions) {
     throw new Error('File not exists: ' + inFile);
   }
 
-  // Regular expressions for audio codecs
-  const audioCodecRegex = /(mp3|aac|wav|flac|ogg|wma|opus|amr|m4a)/i,      // All known extension names of audio file
-        noExtRegex = new RegExp(`(.+)(?:\\.${audioCodecRegex.source})$`);  // Get the file name without its extension
-
   // Create the output file name and change the file extension
-  const outFile = path.join(
+  let outFile = path.join(
     path.dirname(inFile),
-    `${noExtRegex.exec(path.basename(inFile))[1]}.${options.format}`
+    `${path.basename(inFile).replace(/\.[^/.]+$/, '')}.${(options.format
+      || (() => {
+        let index = 0;
+        if (Array.isArray(options.outputOptions) && options.outputOptions.length > 0) {
+          options.outputOptions.forEach((opt, idx) => {
+            if (opt.match(/^-(acodec|c:a)/)) index = idx;
+          });
+          return options.outputOptions[index].split(' ')[1];
+        }
+        return null;
+      })()
+      || path.extname(inFile).replace(/^\./, ''))
+    }`
   );
 
   // Store the file names only without their path directories
   const ioBaseFile = [
-    path.basename(inFile),
-    path.basename(outFile)
+    path.basename(inFile).replace(/\.[^/.]+$/, ''),
+    path.basename(outFile).replace(/\.[^/.]+$/, '')
   ];
   const extnames = [
     path.extname(inFile).replace('.', ''),
     path.extname(outFile).replace('.', '')
   ];
 
-  quiet || log.info(`Processing audio for \x1b[93m${
-    noExtRegex.exec(ioBaseFile[0])[1]}\x1b[0m ...`);
+  // Logic to prevent crash due to write the same file in-place
+  if (inFile === outFile) {
+    ioBaseFile[1] = ioBaseFile[1] + ' (copy)';
+    outFile = path.join(path.dirname(outFile), `${ioBaseFile[1]}.${extnames[1]}`);
+  }
+
+  quiet || log.info(`Processing audio for \x1b[93m${ioBaseFile[0]}\x1b[0m ...`);
 
   // Check whether the `ffmpeg` binary is installed
   if (!(await checkFfmpeg())) {
@@ -298,15 +376,40 @@ async function convertAudio(inFile, options = defaultOptions) {
 
   await new Promise((resolve, reject) => {
     // Perform audio conversion using ffmpeg
-    ffmpeg(inFile)  // Input
-      // Options
-      .audioBitrate(options.bitrate)
-      .audioCodec(options.codec)
-      .audioChannels(options.channels)
-      .audioFrequency(options.frequency)
-      .outputFormat(options.format)
+    const ffmpegChain = ffmpeg()
+      .addInput(inFile)  // IN
+      .output(outFile);  // OUT
 
-      // Handlers
+    // Only add non-custom options (e.g., bitrate, codec) if the `inputOptions`
+    // and `outputOptions` are not set or they are an empty array, this make the
+    // custom options are more prioritized
+    if (
+      (
+        isNullOrUndefined(options.inputOptions)
+          || (Array.isArray(options.inputOptions) && options.inputOptions.length === 0)
+      ) && (
+        isNullOrUndefined(options.outputOptions)
+          || (Array.isArray(options.outputOptions) && options.outputOptions.length === 0)
+      )
+    ) {
+      ffmpegChain
+        .audioBitrate(options.bitrate)
+        .audioCodec(options.codec)
+        .audioChannels(options.channels)
+        .audioFrequency(options.frequency)
+        .outputFormat(options.format);
+    } else {
+      if (Array.isArray(options.inputOptions)) {
+        ffmpegChain.inputOptions(options.inputOptions);
+      }
+
+      if (Array.isArray(options.outputOptions)) {
+        ffmpegChain.outputOptions(options.outputOptions);
+      }
+    }
+
+    // Handlers
+    ffmpegChain
       .on('error', (err) => {
         if (!quiet) {
           process.stdout.write('\n');
@@ -332,8 +435,9 @@ async function convertAudio(inFile, options = defaultOptions) {
           fs.rmSync(inFile);
         }
         resolve();
-      })
-      .save(outFile);  // Output
+      });
+
+    ffmpegChain.run();
   });
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -106,6 +106,21 @@ function createDirIfNotExistSync(dirpath) {
 }
 
 /**
+ * Creates the error log file with the specified prefix.
+ * If the prefix is not specified, it will use `'ytmp3Error'` as the prefix.
+ *
+ * @param {string} [prefix='ytmp3Error'] - The prefix of the error log file.
+ *
+ * @return {string} The created error log file.
+ * @private
+ * @since  1.0.0
+ */
+function createLogFile(prefix) {
+  return `${prefix || 'ytmp3Error'}-${
+    (new Date()).toISOString().split('.')[0].replace(/:/g, '.')}.log`;
+}
+
+/**
  * Checks if a given value is null or undefined.
  *
  * @param {any} x - The value to check.
@@ -409,6 +424,7 @@ module.exports = Object.freeze({
   isObject,
   createDirIfNotExist,
   createDirIfNotExistSync,
+  createLogFile,
   dropNullAndUndefined,
   ProgressBar
 });

--- a/lib/ytmp3.js
+++ b/lib/ytmp3.js
@@ -56,7 +56,8 @@ const {
   logger: log,
   ProgressBar,
   createDirIfNotExist,
-  createDirIfNotExistSync
+  createDirIfNotExistSync,
+  createLogFile
 } = require('./utils');
 const {
   checkFfmpeg,
@@ -369,7 +370,7 @@ async function getVideosInfo(...urls) {
  * @private
  * @since  1.0.0
  */
-function writeLogError(logfile, videoData, error) {
+function writeErrorLog(logfile, videoData, error) {
   if (!logfile || typeof logfile !== 'string') return;
 
   logfile = path.join(LOGDIR, path.basename(logfile));
@@ -437,18 +438,6 @@ async function* downloadAudio(...urls) {
   }
 }
 
-/**
- * Creates the error log file, prefixed with `'ytmp3Error'`.
- *
- * @return {string} The created error log file.
- * @private
- * @since  1.0.0
- */
-function createLogFile() {
-  return `ytmp3Error-${
-    (new Date()).toISOString().split('.')[0].replace(/:/g, '.')}.log`;
-}
-
 
 /**
  * 
@@ -483,7 +472,7 @@ async function downloadHandler(readable, data, verbose=false) {
         // Close the output stream if it's still open
         data.outStream.closed || data.outStream.close();
 
-        writeLogError(data.errLogFile, data.videoData, err);
+        writeErrorLog(data.errLogFile, data.videoData, err);
         reject(err);
       })
       .pipe(data.outStream);

--- a/lib/ytmp3.js
+++ b/lib/ytmp3.js
@@ -561,6 +561,7 @@ async function singleDownload(inputUrl, downloadOptions) {
       } catch (err) {
         if (!quiet) {
           log.error(err.message);
+          console.error(err.stack);
           log.warn('Skipping audio conversion for this file');
         }
       }

--- a/test/unittest/audioconv.spec.mjs
+++ b/test/unittest/audioconv.spec.mjs
@@ -73,6 +73,8 @@ describe('module:audioconv', function () {
 
     before(function () {
       expectedOptions.push({
+        inputOptions: [],
+        outputOptions: [],
         format: 'mp3',
         codec: 'libmp3lame',
         bitrate: 128,

--- a/test/unittest/audioconv.spec.mjs
+++ b/test/unittest/audioconv.spec.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import path from 'node:path';
-import { spawn } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 
 import audioconv from '../../lib/audioconv.js';
 
@@ -18,19 +18,12 @@ describe('module:audioconv', function () {
   };
   let hasFfmpeg = false;
 
-  before(async function () {
+  before(function () {
     try {
-      const { status } = await spawn('ffmpeg -version', { shell: true });
-      hasFfmpeg = (status === 0) ? true : false;  // Prevent return `true` if null or undefined
+      const { status } = spawnSync('ffmpeg -version', { shell: true });
+      hasFfmpeg = (status === 0);  // Prevent return `true` if null or undefined
     } catch (_err) {
       hasFfmpeg = false;
-    }
-
-    // Double check if ffmpeg is installed
-    if (process.platform === 'win32') {
-      hasFfmpeg = (hasFfmpeg === !(await spawn('where.exe ffmpeg', { shell: true }).status));
-    } else {
-      hasFfmpeg = (hasFfmpeg === !(await spawn('which ffmpeg', { shell: true }).status));
     }
   });
 
@@ -39,25 +32,28 @@ describe('module:audioconv', function () {
 
     let ffmpegPath;
     let consoleLog = null;
+    let consoleError = null;
 
     before(function () {
       ffmpegPath = process.env.FFMPEG_PATH || '';
       consoleLog = console.log;
       console.log = () => {};
+      console.error = () => {};
       process.env.FFMPEG_PATH = '';
     });
 
     it(testMessages.checkFfmpeg[0], async function () {
-      assert.equal(await audioconv.checkFfmpeg(false), hasFfmpeg);
+      assert.equal(await audioconv.checkFfmpeg(true), hasFfmpeg);
     });
 
     it(testMessages.checkFfmpeg[1], async function () {
       process.env.FFMPEG_PATH = path.resolve('.');
-      await assert.rejects(audioconv.checkFfmpeg(false), Error);
+      await assert.rejects(audioconv.checkFfmpeg(true), Error);
     });
 
     after(function () {
       console.log = consoleLog;
+      console.error = consoleError;
       process.env.FFMPEG_PATH = ffmpegPath;
     });
   });

--- a/test/unittest/config.spec.mjs
+++ b/test/unittest/config.spec.mjs
@@ -31,6 +31,8 @@ describe('module:config', function () {
     convertAudio: true,
     quiet: false,
     converterOptions: {
+      inputOptions: undefined,
+      outputOptions: undefined,
       format: 'opus',
       codec: 'libopus',
       frequency: 12000,


### PR DESCRIPTION
## Overview

This pull request introduces new command-line options for audio conversion, enhances error logging capabilities, and refactors several utility functions within the project. The improvements aim to provide users with greater flexibility when using FFmpeg options, while also ensuring better error handling and logging mechanisms.

## Notable Changes

### New Features

- **Audio Conversion Options**:
  - Added the ability to specify custom FFmpeg input and output options via new command-line arguments. This change empowers users to fine-tune their audio conversion processes according to specific needs.

- **Logging Enhancements**:
  - Introduced a new helper function for log file creation, allowing more consistent log management.
  - Added a dedicated error logging function during the audio conversion process to ensure that errors are properly recorded and accessible for troubleshooting.

### Refactoring

- Refactored the `createLogFile` function to the `utils` module, centralizing the log file creation process and removing redundant code from the `ytmp3` module.
- Improved the FFmpeg checker to issue warnings only if the `FFMPEG_PATH` environment variable is set and not empty.

### Testing

- Updated test suites to include the new audio conversion options and improved the FFmpeg checker tests for more comprehensive coverage.

## Summary

This update brings more flexibility to the command-line interface by introducing new options that allow users to specify custom FFmpeg input and output parameters. Enhanced logging and error handling functionalities improve the overall user experience by making the software more reliable and easier to debug. Key changes include the addition of `inputOptions` and `outputOptions`, along with the refactoring of logging mechanisms to the `utils` module.

---

## New Command-Line Options

| Option Name       | Aliases                                               | Description                                                        |
|-------------------|-------------------------------------------------------|--------------------------------------------------------------------|
| `--input-options` | `--inputOptions`, `--addInputOptions`, `--add-input-options`, `--inOpt`  | Specifies custom FFmpeg input options for audio conversion.        |
| `--output-options`| `--outputOptions`, `--addOptions`, `--add-options`, `--addOutputOptions`, `--add-output-options`, `--outOpt` | Specifies custom FFmpeg output options for audio conversion.       |

These options allow users to customize how input files are processed and how output files are generated, offering more granular control over the audio conversion process.