### PR TITLE
Add `VERSION_INFO` constant for more structured version information

### DIFF
--- a/index.js
+++ b/index.js
@@ -455,6 +455,7 @@ module.exports = Object.freeze({
   // :: ytmp3 (Core)
   name: ytmp3.name,
   version: ytmp3.version,
+  version_info: ytmp3.VERSION_INFO,
   singleDownload: ytmp3.singleDownload,
   batchDownload: ytmp3.batchDownload,
   getVideosInfo: ytmp3.getVideosInfo,

--- a/index.js
+++ b/index.js
@@ -455,6 +455,7 @@ module.exports = Object.freeze({
   // :: ytmp3 (Core)
   name: ytmp3.name,
   version: ytmp3.version,
+  // eslint-disable-next-line camelcase
   version_info: ytmp3.VERSION_INFO,
   singleDownload: ytmp3.singleDownload,
   batchDownload: ytmp3.batchDownload,

--- a/lib/ytmp3.js
+++ b/lib/ytmp3.js
@@ -30,7 +30,7 @@
  *   .catch(err => console.error('Download failed:', err));
  *
  * @module    ytmp3
- * @version   1.0.0
+ * @version   1.1.0
  * @requires  audioconv
  * @requires  utils
  * @requires  url-utils
@@ -117,22 +117,48 @@ const URLUtils = require('./url-utils');
  * @since   1.0.0
  */
 
+
+// region Constants
+
 /**
- * The library version.
+ * The library name.
  * @constant
  * @default
  * @public
  */
+const NAME = 'ytmp3';
+
+/**
+ * The library version.
+ * @constant
+ * @public
+ */
 const VERSION = require('../package.json').version;
+
+/**
+ * The library version information in a frozen object.
+ *
+ * @property {number} major - The major version number.
+ * @property {number} minor - The minor version number.
+ * @property {number} patch - The patch version number.
+ * @property {string} build - The build information of current version (i.e., stable).
+ *
+ * @readonly
+ * @public
+ * @since    1.1.0
+ */
+const VERSION_INFO = (() => {
+  const [ major, minor, patch, build ] = VERSION.split(/[.-]/g);
+  return Object.freeze({
+    major: Number.parseInt(major),
+    minor: Number.parseInt(minor),
+    patch: Number.parseInt(patch),
+    build: !build ? 'stable' : build });
+})();
+delete VERSION_INFO.prototype;
 
 // Prevent the 'ytdl-core' module to check updates
 Object.assign(process.env, { YTDL_NO_UPDATE: true });
-
-const FrozenProperty = {
-  writable: false,
-  configurable: false,
-  enumerable: true
-};
 
 /**
  * The audio format options for the `ytdl.downloadFromInfo()` function.
@@ -144,6 +170,9 @@ const AUDIO_FMT_OPTIONS = {
   quality: 140,
   filter: 'audioonly'
 };
+
+
+// region Helpers
 
 
 /**
@@ -298,6 +327,8 @@ function resolveDlOptions({ downloadOptions }) {
   };
 }
 
+
+// region Core Functions
 
 
 /**
@@ -715,20 +746,16 @@ async function batchDownload(inputFile, downloadOptions) {
   return successDownloads;
 }
 
-
-
-//==-----------------------==//
-//---===== [EXPORTS] =====---//
-//==-----------------------==//
-
-const ytmp3 = Object.create(null, {
-  ProgressBar: { value: ProgressBar, ...FrozenProperty },
-  resolveDlOptions: { value: resolveDlOptions, ...FrozenProperty },
-  getVideosInfo: { value: getVideosInfo, ...FrozenProperty },
-  singleDownload: { value: singleDownload, ...FrozenProperty },
-  batchDownload: { value: batchDownload, ...FrozenProperty },
-  name: { value: 'ytmp3', ...FrozenProperty },
-  version: { value: VERSION, ...FrozenProperty },
+module.exports = Object.freeze({
+  NAME,
+  VERSION,
+  VERSION_INFO,
+  validateYTURL,
+  resolveDlOptions,
+  downloadAudio,
+  downloadHandler,
+  getVideosInfo,
+  writeErrorLog,
+  singleDownload,
+  batchDownload
 });
-
-module.exports = Object.freeze(ytmp3);


### PR DESCRIPTION
## Overview

This pull request introduces a new public constant `VERSION_INFO` to the `ytmp3` module, which provides detailed version information in a structured and immutable format. Along with this addition, the module version has been updated to 1.1.0, and some refactoring has been done to the module exports.

## Key Changes

### Feature Addition
- **`VERSION_INFO` Constant:**
  - Declared a new public constant `VERSION_INFO` that encapsulates version information in a frozen object. The `VERSION_INFO` object includes the following read-only properties:
    - `major`: Represents the major version number.
    - `minor`: Represents the minor version number.
    - `patch`: Represents the patch version number.
    - `build`: Represents the build metadata, which can indicate the current development stage (e.g., `'beta'` or `'stable'`).

    ```typescript
    const VERSION_INFO: {
      major: number;
      minor: number;
      patch: number;
      build: 'stable' | 'beta';
    }
    ```

### Refactoring
- **Module Version Update:**
  - Updated the `ytmp3` module version to `1.1.0` to reflect the introduction of the new constant and the associated enhancements.

- **Refactor Module Exports:**
  - Refactored the module exports to incorporate the new `VERSION_INFO` constant and ensure a cleaner, more organized export structure.

## Example Usage
```js
import { VERSION_INFO } from 'ytmp3-js';

console.log(VERSION_INFO);
// Output: { major: 1, minor: 1, patch: 0, build: 'beta' }
```

## Summary

This update provides a more structured way to access version information within the `ytmp3` module. By introducing the `VERSION_INFO` constant, developers can programmatically access detailed version data, enhancing version control and tracking in their projects.