### PR TITLE
Fix reliable error logging in `writeErrorLog` function

### DIFF
--- a/lib/ytmp3.js
+++ b/lib/ytmp3.js
@@ -375,7 +375,12 @@ async function getVideosInfo(...urls) {
 }
 
 /**
- * Writes an error message to a specific log file.
+ * Writes error details and associated video information to a log file.
+ * 
+ * This function creates or appends to a log file in the {@link module:utils~LOGDIR `LOGDIR`}
+ * directory, logging the error message along with relevant video data. If the log file is empty
+ * after writing, it will be deleted, and the function returns `false`. Otherwise, it 
+ * returns `true` to indicate successful logging.
  *
  * The error message is written to the log file in the following format:
  *
@@ -389,13 +394,17 @@ async function getVideosInfo(...urls) {
  * ---------------------------------------------
  * ```
  *
- * Immediately return if the given log file name is invalid. The error log
- * will be in the {@link module:utils~LOGDIR LOGDIR} directory.
+ * Immediately return `false` if the given log file name is invalid. The error log
+ * will be in the {@link module:utils~LOGDIR `LOGDIR`} directory.
  *
- * @param {string} logfile - The log file name without the path.
- * @param {VideoData} videoData - The video information to write to the log file.
+ * @param {string} logfile - The name of the log file where the error details should be written.
+ * @param {VideoData | Object} videoData - An object containing information about the video associated
+ *                                         with the error.
  * @param {Error} [error] - The error object, optional. If not provided,
  *                          an error message will be `'Unknown error'`.
+ *
+ * @returns {Promise<boolean>} A promise that resolves to `true` if the log was written
+ *                             successfully, otherwise `false`.
  *
  * @async
  * @private

--- a/lib/ytmp3.js
+++ b/lib/ytmp3.js
@@ -401,22 +401,33 @@ async function getVideosInfo(...urls) {
  * @private
  * @since  1.0.0
  */
-function writeErrorLog(logfile, videoData, error) {
-  if (!logfile || typeof logfile !== 'string') return;
+async function writeErrorLog(logfile, videoData, error) {
+  if (!logfile || typeof logfile !== 'string') return false;
 
   logfile = path.join(LOGDIR, path.basename(logfile));
   createDirIfNotExistSync(LOGDIR);
 
-  const logStream = fs.createWriteStream(logfile, { flags: 'a+', flush: true });
+  return new Promise((resolve) => {
+    const logStream = fs.createWriteStream(logfile, { flags: 'a+', flush: true });
+  
+    // Write the necessary video information to the log file
+    logStream.write(`[ERROR] ${error?.message || 'Unknown error'}${os.EOL}`);
+    logStream.write(`   Title: ${videoData.title}${os.EOL}`);
+    logStream.write(`   Author: ${videoData.author}${os.EOL}`);
+    logStream.write(`   Channel ID: ${videoData.channelId}${os.EOL}`);
+    logStream.write(`   Viewers: ${videoData.viewers}${os.EOL}`);
+    logStream.write(`   URL: ${videoData.videoUrl}${os.EOL}`);
+    logStream.write(`---------------------------------------------${os.EOL}`);
+    logStream.end(os.EOL);
 
-  // Write the necessary video information to the log file
-  logStream.write(`[ERROR] ${error?.message || 'Unknown error'}${os.EOL}`);
-  logStream.write(`   Title: ${videoData.title}${os.EOL}`);
-  logStream.write(`   Author: ${videoData.author}${os.EOL}`);
-  logStream.write(`   Channel ID: ${videoData.channelId}${os.EOL}`);
-  logStream.write(`   Viewers: ${videoData.viewers}${os.EOL}`);
-  logStream.write(`   URL: ${videoData.videoUrl}${os.EOL}`);
-  logStream.write(`---------------------------------------------${os.EOL}${os.EOL}`);
+    logStream.on('finish', () => {
+      if (fs.statSync(logfile).size === 0) {
+        fs.rmSync(logfile);
+        resolve(false);
+      }
+      resolve(true);
+    });
+  });
 }
 
 


### PR DESCRIPTION
## Overview

This pull request addresses the reliability issues with the `writeErrorLog` function, which was previously experiencing occasional race conditions, leading to inconsistent behavior in logging errors.

## Description

### Fixed Unreliable Error Logger
- The `writeErrorLog` function has been revised to ensure that error logs are written reliably and without race conditions. The function now operates fully asynchronously and is designed to return a boolean value to indicate success (`true`) or failure (`false`) in logging the error.

### Documentation Update
- The documentation for the `writeErrorLog` function has been updated to reflect the changes and provide clearer guidance on its usage.

## Summary

This patch ensures that error logs occurred during download process are consistently and accurately written, improving the robustness of the logging system. The function now handles logging in a way that avoids the previous issues, making it a more reliable component of the system.