### PR TITLE
Improve logging reliability and fix export consistency issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -453,8 +453,8 @@ async function main() {
 
 module.exports = Object.freeze({
   // :: ytmp3 (Core)
-  name: ytmp3.name,
-  version: ytmp3.version,
+  name: ytmp3.NAME,
+  version: ytmp3.VERSION,
   // eslint-disable-next-line camelcase
   version_info: ytmp3.VERSION_INFO,
   singleDownload: ytmp3.singleDownload,

--- a/lib/ytmp3.js
+++ b/lib/ytmp3.js
@@ -197,14 +197,11 @@ function validateYTURL(url, verbose=false) {
   // Parse the given URL string
   url = (typeof url === 'string') ? new URL(url) : url;
 
-  verbose && process.stdout.write(
-    `${log.INFO_PREFIX} Validating URL, please wait...`);
+  verbose && log.info('Validating URL, please wait...');
   if (URLUtils.validateUrl(url)) {
-    verbose && process.stdout.write(
-      `\n${log.DONE_PREFIX} \x1b[92m\u2714\x1b[0m URL is valid\n`);
+    verbose && log.done('\x1b[92m\u2714\x1b[0m URL is valid');
   } else {
-    verbose && process.stderr.write(
-      `\n${log.ERROR_PREFIX} \x1b[91m\u2716\x1b[0m URL is invalid\n`);
+    verbose && log.error('\x1b[91m\u2716\x1b[0m URL is invalid');
     throw new Error('Invalid URL: ' + url);
   }
 }

--- a/lib/ytmp3.js
+++ b/lib/ytmp3.js
@@ -522,9 +522,7 @@ async function downloadHandler(readable, data, verbose=false) {
 
         // Close the output stream if it's still open
         data.outStream.closed || data.outStream.close();
-
-        writeErrorLog(data.errLogFile, data.videoData, err);
-        reject(err);
+        writeErrorLog(data.errLogFile, data.videoData, err).then(() => reject(err));
       })
       .pipe(data.outStream);
   });


### PR DESCRIPTION
## Overview
This pull request addresses several issues related to logging reliability and export inconsistencies. The changes focus on ensuring that errors are logged appropriately and that the exported members are correctly named for consistent usage.

## Key Changes

### Fixes
- **925ceec - Ensure that logging is done before exit:**
  - Updated the `writeErrorLog` function to include a promise chain that ensures logging completes before the function exits. This prevents any race conditions and ensures that error logs are reliably recorded before the error is handled.
- **b0f04e8 - Replace the logging method:**
  - Replaced the direct use of `process.std*.write` with the `utils.logger` methods in the `validateYTURL` function. This change improves logging control and makes the logging process more reliable and consistent with the rest of the codebase.
- **443f627 - Fix mismatch in exported members' names:**
  - Corrected the naming of exported members in the `index` module to ensure they match the intended export names. This resolves an issue that has persisted since change #33, and we apologize for any inconvenience this may have caused.

## Summary
These fixes are essential for maintaining the stability and reliability of the `ytmp3` module, particularly in error handling and logging processes.