### PR TITLE
Enhance FFmpeg option handling and add new flexibility

### DIFF
--- a/lib/audioconv.js
+++ b/lib/audioconv.js
@@ -39,7 +39,8 @@ const {
   createDirIfNotExistSync,
   createLogFile,
   dropNullAndUndefined,
-  isNullOrUndefined
+  isNullOrUndefined,
+  isObject
 } = require('./utils');
 
 /**
@@ -193,7 +194,9 @@ function splitOptions(options) {
  * @return {module:audioconv~ResolvedConvertAudioOptions} The resolved options.
  * @since  1.0.0
  */
-function resolveOptions(options, useDefault=true) {
+function resolveOptions(options, useDefault=false) {
+  if (!isObject(options)) return defaultOptions;
+
   return {
     inputOptions: (
       Array.isArray(options?.inputOptions)
@@ -457,12 +460,18 @@ async function convertAudio(inFile, options = defaultOptions) {
           || (Array.isArray(options.outputOptions) && options.outputOptions.length === 0)
       )
     ) {
-      ffmpegChain
-        .audioBitrate(options.bitrate)
-        .audioCodec(options.codec)
-        .audioChannels(options.channels)
-        .audioFrequency(options.frequency)
-        .outputFormat(options.format);
+      // Add each option only if present and specified
+      // By using this logic, now user can convert an audio file with only specifying
+      // the output audio format
+      if (options.bitrate) ffmpegChain.audioBitrate(options.bitrate);
+      if (options.codec) ffmpegChain.audioCodec(options.codec);
+      if (options.channels) ffmpegChain.audioChannels(options.channels);
+      if (options.frequency) ffmpegChain.audioFrequency(options.frequency);
+
+      // Mandatory for output format
+      // Note: Specifying the same output format as input may copy the input file
+      //       with the same codec and format
+      ffmpegChain.outputFormat(options.format);
     } else {
       if (Array.isArray(options.inputOptions)) {
         ffmpegChain.inputOptions(options.inputOptions);

--- a/test/unittest/audioconv.spec.mjs
+++ b/test/unittest/audioconv.spec.mjs
@@ -12,7 +12,7 @@ describe('module:audioconv', function () {
     ],
     resolveOptions: [
       'should return default options if given argument is nullable value',
-      'should return nullable options if given argument is nullable value',
+      'should return default options if given argument is not an object',
       'should resolve the given configuration options'
     ]
   };
@@ -92,7 +92,7 @@ describe('module:audioconv', function () {
     });
 
     it(testMessages.resolveOptions[0], function () {
-      const actualOptions = [null, undefined, {}].map((val) => {
+      const actualOptions = [null, undefined, false].map((val) => {
         return audioconv.resolveOptions(val , true);
       });
 
@@ -110,15 +110,16 @@ describe('module:audioconv', function () {
     });
 
     it(testMessages.resolveOptions[1], function () {
-      const actualOptions = [null, undefined, {}].map((val) => {
+      const actualOptions = ['&', /y/, 16n].map((val) => {
         return audioconv.resolveOptions(val , false);
       });
 
       actualOptions.forEach((actual) => {
         assert.notStrictEqual(actual, null);  // Non-nullable
         assert.notStrictEqual(typeof actual, 'undefined');
-        assert.notDeepStrictEqual(actual, expectedOptions[0]);
-        assert.deepStrictEqual(actual, expectedOptions[2]);
+        assert.deepStrictEqual(actual, expectedOptions[0]);
+        assert.notDeepStrictEqual(actual, expectedOptions[1]);
+        assert.notDeepStrictEqual(actual, expectedOptions[2]);
       });
       [...actualOptions].reverse().forEach((actual1) => {
         actualOptions.forEach((actual2) => {


### PR DESCRIPTION
## Overview
This refactor introduces enhanced flexibility in the `audioconv` module by refining the way options are handled and applied within the `convertAudio` function. The changes allow users to specify minimal configurations while still leveraging the full capabilities of `ffmpeg`.

## Changes Made
- **Enhanced `resolveOptions` Logic**:
  - The `resolveOptions` function now returns `defaultOptions` if the input is either an empty object or a non-object. This improvement ensures a more robust handling of edge cases where invalid or empty options are passed.
  - Default value of `useDefault` are now set to `false` for compatibility with minimal FFmpeg options.

- **Selective Application of FFmpeg Audio Options**:
  - The `convertAudio` function has been updated to apply audio options (`bitrate`, `codec`, `channels`, `frequency`) only if they are explicitly provided by the user. This enhancement allows users to convert audio files with just the necessary settings, reducing the need for redundant configurations and prevent an error thrown by `ffmpeg` due to `undefined` option has given.
  - The output format remains a mandatory option, ensuring that the conversion process is correctly executed with the specified format. Additionally, users can now specify the same format as the input file, potentially copying the input file with the same codec and format, if desired.

## Benefits
- **Increased Flexibility**: Users can now perform conversions with minimal configurations, specifying only the options they need.
- **Simplified Usage**: The refactor reduces complexity for users by automatically handling default settings when no specific options are provided.
- **Better Error Handling**: The update in `resolveOptions` enhances the module’s robustness, avoiding potential issues from invalid inputs.

It's now possible to convert an audio file by specifying only the output format, for examples:

- Using `ytmp3` CLI:
  ```bash
  ytmp3 <URL> -C --format opus
  ```

- Using `convertAudio` API function:
  ```javascript
  import { convertAudio } from 'ytmp3-js';

  // Convert an audio file to opus format
  await convertAudio('/path/to/audio.mp3', {
    // Only specify the output format
    format: 'opus'
  });
  // Or you can use 'outputOptions' instead
  await convertAudio('/path/to/audio.mp3', {
    outputOptions: '-f opus'
  });
  ```
