### PR TITLE
Add option to force `require()` for config files handling

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,33 @@
+module.exports = {
+  // Executions
+  bail: false,
+  parallel: false,
+  jobs: 1,
+  retries: 0,
+  color: true,
+  reporter: 'spec',
+  'node-option': [],
+  // Diffs
+  diff: false,
+  'inline-diffs': true,
+  'full-trace': false,  // Enable this if want to more verbose in debugging
+  // Files
+  recursive: true,
+  extensions: [
+    '.spec.js', '.spec.cjs', '.spec.mjs',
+    '.test.js', '.test.cjs', '.test.mjs'
+  ],
+  ignore: [
+    'test/assets/**',
+    'tmp/**',
+    'coverage/**',
+    'docs/**'
+  ],
+  // Restrictions
+  global: [],
+  'check-leaks': false,
+  'allow-uncaught': false,
+  'async-only': false,
+  'forbid-only': true,
+  'forbid-pending': false
+};

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,8 +1,12 @@
 {
   "all": false,
-  "check-coverage": false,
+  "check-coverage": true,
   "reporter": ["lcov", "text"],
   "report-dir": "./coverage",
+  "exclude": [
+    ".mocharc.js",
+    "tmp/**"
+  ],
   "branches": 50,
   "functions": 65,
   "lines": 50,

--- a/lib/audioconv.js
+++ b/lib/audioconv.js
@@ -519,6 +519,9 @@ async function convertAudio(inFile, options = defaultOptions) {
 
 module.exports = Object.freeze({
   defaultOptions,
+  splitOptions,
+  writeErrorLog,
+  createConversionProgress,
   resolveOptions,
   checkFfmpeg,
   convertAudio

--- a/lib/audioconv.js
+++ b/lib/audioconv.js
@@ -486,10 +486,18 @@ async function convertAudio(inFile, options = defaultOptions) {
     ffmpegChain
       .on('error', (err) => {
         quiet || process.stdout.write('\n');
+        // Safely get the input file size and prevent any error
+        // if the input file has been deleted unexpectedly
+        let inputSize = NaN;
+        try {
+          inputSize = fs.statSync(inFile).size;
+        // eslint-disable-next-line no-unused-vars
+        } catch (_statErr) { }
+
         writeErrorLog(createLogFile('audioConvError'), {
-          inputFile: inFile,
-          outputFile: outFile,
-          inputSize: fs.statSync(inFile).size
+          inputAudio: inFile,
+          outputAudio: outFile,
+          inputSize
         }, err).then(() => {
           if (!quiet) {
             log.error('Failed to convert the audio file');

--- a/lib/config.js
+++ b/lib/config.js
@@ -265,7 +265,7 @@ function configChecker({ config, file }) {
  * @see     {@link module:config~importConfig importConfig}
  *          (alias for <code>parseConfig(config, true)</code>)
  */
-function parseConfig(configFile, resolve=true) {
+function parseConfig(configFile, resolve=true, forceRequire=false) {
   function resolveOrCheckOnly(config) {
     // Attempt to extract the default export (only on ES module) if the configuration
     // object only contains that 'default' property, for clarity:
@@ -294,15 +294,17 @@ function parseConfig(configFile, resolve=true) {
     }`);
   }
 
-  // Resolve the configuration file path
-  configFile = path.resolve(configFile);
-
   // Import the configuration file
   let config = null;
   // Only include '.cjs' and '.json' to use require()
-  if (KNOWN_CONFIG_EXTS.slice(2).includes(path.extname(configFile))) {
+  if (KNOWN_CONFIG_EXTS.slice(2).includes(path.extname(configFile))
+      || forceRequire) {
     config = require(configFile);
   } else {
+    // On Windows, replace all '\' with '/' to use import()
+    if (process.platform === 'win32') {
+      configFile = 'file:///' + configFile.replace(/\\/g, '/');
+    }
     config = import(configFile);
   }
 
@@ -328,7 +330,7 @@ function parseConfig(configFile, resolve=true) {
  * @since  1.0.0
  * @see    {@link module:config~parseConfig parseConfig}
  */
-const importConfig = (file) => parseConfig(file, true);
+const importConfig = (file, forceRequire=false) => parseConfig(file, true, forceRequire);
 
 
 module.exports = Object.freeze({

--- a/test/irl.test.mjs
+++ b/test/irl.test.mjs
@@ -9,15 +9,25 @@ import {
   getTempPath,
   createTempPath as _createTempPath
 } from '@mitsuki31/temppath';
+import ffmpeg from 'fluent-ffmpeg';
 
 import audioconv from '../lib/audioconv.js';
 import ytmp3 from '../lib/ytmp3.js';
 import utils from '../lib/utils.js';
 
+const ffprobe = promisify(ffmpeg.ffprobe);
 const createTempPath = promisify(_createTempPath);
+const ASSETS_DIR = path.join(utils.ROOTDIR, 'test', 'assets');
+const AUDIO_ASSETS_DIR = path.join(ASSETS_DIR, 'audio');
+
+function getAudioFile(filename) {
+  const audioPath = path.join(AUDIO_ASSETS_DIR, path.basename(filename));
+  if (!fs.existsSync(audioPath)) throw new Error(`No such audio file: ${filename}`);
+  return audioPath;
+}
 
 describe('IRL (In Real Life) Test', function () {
-  console.log('\x1b[33mCAUTION! Data charge may apply.\x1b[0m');
+  console.log('\x1b[33mCAUTION! Data charge may apply in several test cases.\x1b[0m');
 
   const videoIDs = [
     'Z0z5mNPODrc',
@@ -26,8 +36,16 @@ describe('IRL (In Real Life) Test', function () {
   ];
   const outDir = getTempPath(path.join(utils.ROOTDIR, 'tmp'), 15);
   const outputFiles = {};
+  // Stubs
+  const consoleLogStub = console.log;
+  const consoleErrorStub = console.error;
 
-  describe('Downloading and converting some YouTube videos to MP3 format', function () {
+  beforeEach(function () {
+    console.log = (...args) => {};
+    console.error = (...args) => {};
+  });
+
+  describe.skip('Downloading and converting some YouTube videos to MP3 format', function () {
     console.log('Please wait for a while...');
 
     for (const id of videoIDs) {
@@ -56,7 +74,7 @@ describe('IRL (In Real Life) Test', function () {
     }
   });
 
-  describe('Downloading some YouTube videos using batch download', function () {
+  describe.skip('Downloading some YouTube videos using batch download', function () {
     let tempFile;
 
     before(async function () {
@@ -66,11 +84,14 @@ describe('IRL (In Real Life) Test', function () {
         ext: 'dl'
       });
 
-      const tempFileStream = fs.createWriteStream(tempFile);
-      for (const id of videoIDs) {
-        tempFileStream.write(`https://youtu.be/${id}${EOL}`);
-      }
-      tempFileStream.end();
+      return new Promise((resolve) => {
+        const tempFileStream = fs.createWriteStream(tempFile);
+        for (const id of videoIDs) {
+          tempFileStream.write(`https://youtu.be/${id}${EOL}`);
+        }
+        tempFileStream.end();
+        tempFileStream.on('finish', resolve);
+      });
     });
 
     it('should succeed to download', async function () {
@@ -85,19 +106,173 @@ describe('IRL (In Real Life) Test', function () {
     });
   });
 
-  after(function () {
-    try {
-      if (fs.existsSync(outDir)) {
-        fs.rmSync(path.dirname(outDir), { recursive: true });
+  describe('Converting audio files to specific formats', function () {
+    const testDynMessages = [
+      'should convert audio file to MP3 format with sample rate of 48kHz',
+      'should convert audio file to OPUS format with audio channel set to mono',
+      'should convert audio file to AAC format with bit rate 320kbps and remove original file'
+    ];
+    const testMessages = [
+      'should reject when the output format is not specified which is mandatory',
+      'should handle the error that occurs while logging error'
+    ];
+    const optionsList = [
+      {
+        format: 'mp3',
+        codec: 'libmp3lame',
+        frequency: 48000,
+        quiet: false
+      },
+      {
+        format: 'opus',
+        codec: 'libopus',
+        channels: 1,
+        quiet: false
+      },
+      {
+        format: 'aac',
+        bitrate: 320,
+        inputOptions: 'testing only! this invalid options will be auto-removed',
+        outputOptions: '-b:a 320k -f mp4 -acodec aac',
+        quiet: false,
+        deleteOld: true
       }
-    } catch (err) {
-      if ('code' in err && err.code === 'EBUSY') {
-        setTimeout(() => {
-          if (fs.existsSync(outDir)) fs.rmSync(outDir, { recursive: true });
-        }, 1000 * 3);  // Wait for 3 seconds
-      } else {
-        throw err;
-      }
+    ];
+    const audioOutputDir = path.join(outDir, 'irl__audio-conversion-test');
+    const audioFile = getAudioFile('testaudio-160-pcm_s32le.wav');
+
+    function getOutFile(inFile, outExt) {
+      return path.join(
+        outDir, path.basename(audioOutputDir),
+        path.basename(inFile).replace(path.extname(inFile), outExt)
+      );
     }
+
+    async function moveOutFile(destFile) {
+      const outputFileOld = path.join(
+        path.dirname(audioFile), path.basename(destFile)
+      );
+      await fs.promises.copyFile(outputFileOld, destFile);
+      await fs.promises.unlink(outputFileOld);
+    }
+
+    // Create output directory, if not exist
+    utils.createDirIfNotExistSync(audioOutputDir);
+
+    optionsList.forEach(function (options, idx) {
+      it(testDynMessages[idx], async function () {
+        this.timeout(1000 * 60 * 5);  // 5 minutes
+        this.slow(1000 * 60 * 2);     // 2 minutes
+
+        let outputFile;
+        let newAudioFile;
+
+        if (idx !== 2) {
+          await audioconv.convertAudio(audioFile, options);
+          outputFile = getOutFile(audioFile, `.${options.format}`);
+          await moveOutFile(outputFile);
+        } else {
+          newAudioFile = path.join(audioOutputDir, path.basename(audioFile));
+          // Duplicate the original audio file to temporary working directory,
+          // this is intended to make sure that the original file does not get
+          // deleted after conversion due to `deleteOld` option is enabled.
+          // Thus, only the duplicate of original file that would be deleted instead
+          await fs.promises.copyFile(audioFile, newAudioFile);
+          await audioconv.convertAudio(newAudioFile, options);
+          outputFile = getOutFile(newAudioFile, `.${options.format}`);
+        }
+
+        assert.ok(fs.existsSync(outputFile));
+        const {
+          streams: inStreams,
+          format: inFormat
+        } = await ffprobe(audioFile);
+        const {
+          streams: outStreams,
+          format: outFormat
+        } = await ffprobe(outputFile);
+
+        // Duration test
+        assert.strictEqual(
+          outStreams[0].duration.toFixed(),
+          inStreams[0].duration.toFixed()
+        );
+        // File size test
+        assert.notStrictEqual(outFormat.size, inFormat.size);
+        assert.strictEqual(outFormat.size, (await fs.promises.stat(outputFile)).size);
+        // Codec name test
+        assert.strictEqual(outStreams[0].codec_name, options.format);
+
+        if (idx === 0) {
+          // Channels test
+          assert.strictEqual(parseInt(outStreams[0].channels), inStreams[0].channels);
+          // Audio resampling test
+          assert.strictEqual(parseInt(outStreams[0].sample_rate), options.frequency);
+        } else if (idx === 1) {
+          // Audio channels test
+          assert.strictEqual(parseInt(outStreams[0].channels), options.channels);
+        } else if (idx === 2) {
+          // Bit rate test
+          assert.ok(parseInt(outStreams[0].bit_rate) / 1000 <= options.bitrate);
+          assert.equal(fs.existsSync(newAudioFile), false);
+        }
+      });
+    });
+
+    it(testMessages[0], async function () {
+      this.slow(800);
+      await assert.rejects(() => {
+        return audioconv.convertAudio(audioFile, {});
+      }, { message: /format.+not available/i });
+    });
+
+    it(testMessages[1], function (done) {
+      this.slow(600);
+
+      const createWriteStreamStub = fs.createWriteStream;
+      const promiseStub = global.Promise;
+      let hasError;
+      fs.createWriteStream = (f, o) => {
+        const stream = createWriteStreamStub(f, o);
+        // Emit error at next tick
+        process.nextTick(() => {
+          if (!hasError) {
+            stream.emit('error', new Error('Simulated error test'));
+          }
+        });
+        return stream;
+      };
+
+      assert.rejects(async () => {
+        return await audioconv.convertAudio(audioFile, {})
+          .catch((err) => {
+            assert.ok(err instanceof Error
+                      && !(err instanceof assert.AssertionError));
+            assert.ok(err.cause instanceof Error);
+            assert.match(err.cause.message, /simulated error test/i);
+          })
+          .finally(done);
+        });
+
+      after(function () {
+        fs.createWriteStream = createWriteStreamStub;
+      })
+    });
+
+    after(async function () {
+      const emptyAudioFiles = (await fs.promises.readdir(AUDIO_ASSETS_DIR))
+        .map((file) => path.join(AUDIO_ASSETS_DIR, file))
+        .filter((file) => {
+          return (fs.statSync(file).size === 0);
+        });
+      // Remove empty audio files in audio assets directory,
+      // error occurred during conversion may create an empty file
+      for (const file of emptyAudioFiles) await fs.promises.unlink(file);
+    });
+  });
+
+  after(function () {
+    // Clean up temporary working directory
+    if (fs.existsSync(outDir)) fs.rmSync(path.dirname(outDir), { recursive: true });
   });
 });

--- a/test/unittest/config.spec.mjs
+++ b/test/unittest/config.spec.mjs
@@ -1,72 +1,235 @@
-/* eslint-disable mocha/no-setup-in-describe */
-
 import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
+import { format } from 'node:util';
+import { tmpdir } from 'node:os';
 
 import config from '../../lib/config.js';
+import utils from'../../lib/utils.js';
+import error from '../../lib/error.js';
+const { UnknownOptionError } = error;
 
 describe('module:config', function () {
   const testMessages = {
     importConfig: [
-      'should parse and resolve the given configuration file'
+      'should parse and resolve the JSON configuration file',
+      'should parse and resolve the ES Module configuration file',
+      'should parse and resolve the CommonJS configuration file',
+      'should throw `TypeError` when configuration file path is not a string',
+      'should throw `Error` if configuration file extension are unknown'
+    ],
+    parseConfig: [
+      'should validate only the configuration file',
+      'should validate and resolve the configuration file'
+    ],
+    resolveConfig: [
+      'should resolve audio conversion options from `converterOptions` field',
+      'should return an empty object when specified configuration with nullable value'
+    ],
+    configChecker: [
+      'should throw `TypeError` if the given config is not an object',
+      'should throw `UnknownOptionError` when found unknown download options',
+      'should throw `TypeError` if any known options is not an object type'
     ]
   };
-  const tempFile = path.join('tmp', 'tempTestConfig.json');
-  const configObj = {
-    downloadOptions: {
-      cwd: null,
-      outDir: path.join('tmp', 'downloads'),
-    },
-    audioConverterOptions: {
-      format: 'opus',
-      codec: 'libopus',
-      frequency: 12000,
-      channels: 1
-    }
-  };
-  const expectedResolvedConfig = {
-    cwd: path.resolve('.'),
-    outDir: path.resolve('.', 'tmp', 'downloads'),
-    convertAudio: true,
-    quiet: false,
-    converterOptions: {
-      inputOptions: undefined,
-      outputOptions: undefined,
-      format: 'opus',
-      codec: 'libopus',
-      frequency: 12000,
-      bitrate: undefined,
-      channels: 1,
-      deleteOld: undefined,
-      quiet: undefined
-    }
-  };
+  let tempFileNoExt;
+  let configObj;
+  let expectedResolvedConfig;
 
-  before(async function () {
-    if (!fs.existsSync(path.dirname(tempFile))) {
-      fs.mkdirSync(path.dirname(tempFile));
-    }
-    const stream = fs.createWriteStream(tempFile, { flush: true });
+  before(function () {
+    tempFileNoExt = path.join(
+      tmpdir(), 'config@unittest',
+      'tempTestConfig'
+    );
+    configObj = {
+      downloadOptions: {
+        cwd: null,
+        outDir: 'tmp/downloads',
+      },
+      audioConverterOptions: {
+        format: 'opus',
+        codec: 'libopus',
+        frequency: 12000,
+        channels: 1
+      }
+    };
+    expectedResolvedConfig = {
+      cwd: path.resolve('.'),
+      outDir: path.resolve('.', 'tmp', 'downloads'),
+      convertAudio: true,
+      quiet: false,
+      converterOptions: {
+        inputOptions: undefined,
+        outputOptions: undefined,
+        format: 'opus',
+        codec: 'libopus',
+        frequency: 12000,
+        bitrate: undefined,
+        channels: 1,
+        deleteOld: undefined,
+        quiet: undefined
+      }
+    };
 
-    // Required to ensure that the stream are closed
-    // before the JSON file being parsed
-    return new Promise((resolve) => {
-      stream.write(JSON.stringify(configObj));
-      stream.close(resolve);
-    });
+    utils.createDirIfNotExistSync(path.dirname(tempFileNoExt));
   });
 
   describe('#importConfig', function () {
     it(testMessages.importConfig[0], async function () {
+      const tempFile = tempFileNoExt + '.json';
+      await new Promise((resolve) => {
+        const stream = fs.createWriteStream(tempFile, { flush: true });
+
+        stream.write(JSON.stringify(configObj));
+        stream.end();
+        stream.on('finish', resolve);
+      });
+
       const resolvedConfig = await config.importConfig(tempFile);
-      assert.ok(resolvedConfig !== null);
-      assert.ok(typeof resolvedConfig !== 'undefined');
+
+      assert.equal(utils.isNullOrUndefined(resolvedConfig), false);
       assert.deepStrictEqual(resolvedConfig, expectedResolvedConfig);
+    });
+
+    it(testMessages.importConfig[1], async function () {
+      const tempFile = tempFileNoExt + '.config.mjs';
+      await new Promise((resolve) => {
+        const stream = fs.createWriteStream(tempFile, { flush: true });
+        const content = `export default ${format(configObj)};`
+          .replace(/(\s{2,}|\r?\n)/g, ' ')
+          .trim().concat('\n');
+
+        stream.write(content);
+        stream.end();
+        stream.on('finish', resolve);
+      });
+
+      const resolvedConfig = await config.importConfig(tempFile);
+
+      assert.equal(utils.isNullOrUndefined(resolvedConfig), false);
+      assert.deepStrictEqual(resolvedConfig, expectedResolvedConfig);
+    });
+
+    it(testMessages.importConfig[2], async function () {
+      const tempFile = tempFileNoExt + '.config.cjs';
+      await new Promise((resolve) => {
+        const stream = fs.createWriteStream(tempFile, { flush: true });
+        const content = `module.exports = ${format(configObj)};`
+          .replace(/(\s{2,}|\r?\n)/g, ' ')
+          .trim();
+
+        stream.write(content);
+        stream.end();
+        stream.on('finish', resolve);
+      });
+
+      const resolvedConfig = await config.importConfig(tempFile);
+
+      assert.equal(utils.isNullOrUndefined(resolvedConfig), false);
+      assert.deepStrictEqual(resolvedConfig, expectedResolvedConfig);
+    });
+
+    it(testMessages.importConfig[3], async function () {
+      await assert.rejects(async () => {
+        await config.importConfig(123n);
+      }, TypeError);
+    });
+
+    it(testMessages.importConfig[4], async function () {
+      await assert.rejects(async () => {
+        await config.importConfig(tempFileNoExt + '.docx');
+      }, Error);
+    });
+  });
+
+  describe('#parseConfig', function () {
+    let tempFile;
+
+    before(async function () {
+      tempFile = tempFileNoExt + '.js';
+
+      await new Promise((resolve) => {
+        const stream = fs.createWriteStream(tempFile, { flush: true });
+        const content = `exports = ${format(configObj)};`
+          .replace(/(\s{2,}|\r?\n)/g, ' ')
+          .trim();
+
+        stream.write(content);
+        stream.end();
+        stream.on('finish', resolve);
+      });
+    });
+
+    it(testMessages.parseConfig[0], async function () {
+      await assert.doesNotReject(async () => {
+        await config.parseConfig(tempFile, false);
+      });
+    });
+
+    it(testMessages.parseConfig[1], async function () {
+      await assert.doesNotReject(async () => {
+        await config.parseConfig(tempFile);
+      });
+    });
+
+    after(function () {
+      if (fs.existsSync(tempFile)) fs.rmSync(tempFile);
+    });
+  });
+
+  describe('#resolveConfig', function () {
+    it(testMessages.resolveConfig[0], function () {
+      assert.doesNotThrow(() => config.resolveConfig({
+        config: {
+          downloadOptions: {
+            converterOptions: {
+              format: 'wav',
+              deleteOld: true
+            }
+          }
+        }
+      }));
+    });
+
+    it(testMessages.resolveConfig[1], function () {
+      [ null, undefined, false ].forEach((cfg) =>
+        assert.deepStrictEqual(config.resolveConfig({ config: cfg }), {}));
+    });
+  });
+
+  describe('#configChecker', function () {
+    let file;
+
+    before(function () {
+      file = path.join(path.dirname(tempFileNoExt), 'example.config.mjs');
+    });
+
+    it(testMessages.configChecker[0], function () {
+      [ null, 5, '_' ].forEach((cfg) =>
+        assert.throws(() => config.configChecker({ config: cfg, file })));
+    });
+
+    it(testMessages.configChecker[1], function () {
+      const cfg = { foo: false };
+      assert.throws(() =>
+        config.configChecker({ config: cfg, file }), UnknownOptionError);
+    });
+
+    it(testMessages.configChecker[2], function () {
+      const configs = [
+        { downloadOptions: true },
+        { audioConverterOptions: '0123' }
+      ];
+      configs.forEach((cfg) => {
+        assert.throws(() =>
+          config.configChecker({ config: cfg, file }), TypeError);
+      });
     });
   });
 
   after(function () {
-    if (fs.existsSync(tempFile)) fs.rmSync(tempFile);
+    if (fs.existsSync(path.dirname(tempFileNoExt))) {
+      fs.rmSync(path.dirname(tempFileNoExt), { recursive: true });
+    }
   });
 });

--- a/test/unittest/url-utils.spec.mjs
+++ b/test/unittest/url-utils.spec.mjs
@@ -39,10 +39,16 @@ describe('module:url-utils', function () {
 
     describe('#extractVideoId', function () {
       const id = 'abcdeQWERTY';  // Valid video ID always have 11 characters
-      const url = `https://www.youtube.com/watch?v=${id}`;
+      let urls;
+
+      before (function () {
+        urls = URLUtils.BASIC_YOUTUBE_DOMAINS.map((url) => {
+          return new URL((url !== 'youtu.be') ? `watch?v=${id}` : id, `https://${url}`);
+        });
+      });
 
       it(testMessages.extractVideoId[0], function () {
-        assert.strictEqual(URLUtils.extractVideoId(url), id);
+        urls.forEach((url) => assert.strictEqual(URLUtils.extractVideoId(url), id));
       });
 
       it(testMessages.extractVideoId[1], function () {
@@ -54,8 +60,12 @@ describe('module:url-utils', function () {
       });
 
       it(testMessages.extractVideoId[2], function () {
-        assert.throws(() =>
-          URLUtils.extractVideoId('https://youtu.be/watch?v=abc'), IDExtractorError);
+        assert.throws(() => {
+          URLUtils.extractVideoId('https://youtu.be/watch?v=abc');
+        }, IDExtractorError);
+        assert.throws(() => {
+          URLUtils.extractVideoId('https://m.youtube.com/channels/UC_12345abcde');
+        }, IDExtractorError);
       });
 
       it(testMessages.extractVideoId[3], function () {
@@ -69,18 +79,22 @@ describe('module:url-utils', function () {
 
       it(testMessages.validateUrl[0], function () {
         assert.ok(URLUtils.validateUrl(exampleValidUrl));
+        assert.ok(URLUtils.validateUrl(new URL(exampleValidUrl)));
       });
 
       it(testMessages.validateUrl[1], function () {
         assert.equal(URLUtils.validateUrl('https://www.google.com/'), false);
+        assert.equal(URLUtils.validateUrl(new URL('https://www.google.com/')), false);
       });
 
       it(testMessages.validateUrl[2], function () {
         assert.equal(URLUtils.validateUrl(exampleInvalidUrl), false);
+        assert.equal(URLUtils.validateUrl(new URL(exampleInvalidUrl)), false);
       });
 
       it(testMessages.validateUrl[3], function () {
         assert.ok(URLUtils.validateUrl(exampleInvalidUrl, false));
+        assert.ok(URLUtils.validateUrl(new URL(exampleInvalidUrl), false));
       });
 
       it(testMessages.validateUrl[4], function () {

--- a/test/unittest/ytmp3.spec.mjs
+++ b/test/unittest/ytmp3.spec.mjs
@@ -1,0 +1,182 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { getTempPath } from '@mitsuki31/temppath';
+
+import ytmp3 from '../../lib/ytmp3.js';
+import audioconv from '../../lib/audioconv.js';
+import utils from '../../lib/utils.js';
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(utils.ROOTDIR, 'package.json'), 'utf8'));
+
+describe('module:ytmp3', function () {
+  const testMessages = {
+    NAME: [
+      'should be a string type',
+      'should be match to "ytmp3"'
+    ],
+    VERSION: [
+      'should be a string type',
+      'should be match to the version in package.json'
+    ],
+    VERSION_INFO: [
+      'should be a frozen object',
+      'should match with `VERSION` value when assembled as a string',
+      'should throw an error (in ESM) when attempting to modify read-only properties'
+    ],
+    validateYTURL: [
+      'should does not throw when given a valid YouTube URL',
+      'should accept a URL object representing a valid YouTube URL as input',
+      'should throw when given an invalid YouTube URL',
+      'should throw when given URL is not a string'
+    ],
+    resolveDlOptions: [
+      'should resolve and validate download options',
+      'should throw when download options are not an object'
+    ],
+    writeErrorLog: [
+      'should write the error to specified file successfully',
+      'should not create a log file when the given file path is not a string'
+    ]
+  };
+
+  describe('~NAME', function () {
+    it(testMessages.NAME[0], function () {
+      assert.strictEqual(typeof ytmp3.NAME, 'string');
+    });
+
+    it(testMessages.NAME[1], function () {
+      assert.strictEqual(ytmp3.NAME, 'ytmp3');
+    });
+  });
+
+  describe('~VERSION', function () {
+    it(testMessages.VERSION[0], function () {
+      assert.strictEqual(typeof ytmp3.VERSION, 'string');
+    });
+
+    it(testMessages.VERSION[1], function () {
+      assert.strictEqual(ytmp3.VERSION, pkg.version);
+    });
+  });
+
+  describe('~VERSION_INFO', function () {
+    it(testMessages.VERSION_INFO[0], function () {
+      assert.ok(utils.isObject(ytmp3.VERSION_INFO));
+      assert.ok(Object.isFrozen(ytmp3.VERSION_INFO));
+    });
+
+    it(testMessages.VERSION_INFO[1], function () {
+      const versionStr = Object.values(ytmp3.VERSION_INFO).reduce((acc, val) => {
+        acc += (typeof val !== 'number' && val.toLowerCase() === 'beta')
+          ? `-${val}`
+          : ((!acc) ? val : `.${val}`);
+        return acc;
+      }, '');
+      assert.strictEqual(versionStr, ytmp3.VERSION);
+    });
+
+    it(testMessages.VERSION_INFO[2], function () {
+      // Attempt to modify the property value
+      assert.throws(() => ytmp3.VERSION_INFO.major = Infinity, {
+        message: /cannot assign/i
+      });
+    });
+  });
+
+  describe('#validateYTURL', function () {
+    let consoleLog = null;
+    let consoleError = null;
+
+    before(function () {
+      // These was intended to suppress `console.log` and
+      // `console.error` logs during tests when verbose mode is enabled
+      consoleLog = console.log;
+      consoleError = console.error;
+      console.log = () => {};
+      console.error = () => {};
+    });
+
+    it(testMessages.validateYTURL[0], function () {
+      // Valid YouTube URLs must have an ID with length of 11 characters
+      assert.doesNotThrow(() => ytmp3.validateYTURL('https://youtu.be/Z0z5mNPODrc', true), Error);
+    });
+
+    it(testMessages.validateYTURL[1], function () {
+      assert.doesNotThrow(() => ytmp3.validateYTURL(
+        new URL('https://youtu.be/Z0z5mNPODrc', 'https://youtube.com'), true),
+        Error
+      );
+    });
+
+    it(testMessages.validateYTURL[2], function () {
+      assert.throws(() => ytmp3.validateYTURL('https://open.spotify.com', true), Error);
+    });
+
+    it(testMessages.validateYTURL[3], function () {
+      assert.throws(() => ytmp3.validateYTURL(123, true), TypeError);
+      assert.throws(() => ytmp3.validateYTURL([], true), TypeError);
+    });
+
+    after(function () {
+      console.log = consoleLog;
+      console.error = consoleError;
+    });
+  });
+
+  describe('#resolveDlOptions', function () {
+    it(testMessages.resolveDlOptions[0], function () {
+      const downloadOptions = {
+        outDir: 'tmp/downloads',
+        quiet: true
+      };
+      const expectedDownloadOptions = {
+        cwd: path.resolve('.'),
+        outDir: path.resolve('.', 'tmp', 'downloads'),
+        convertAudio: true,
+        converterOptions: audioconv.defaultOptions,
+        quiet: true
+      };
+      const actualOptions = ytmp3.resolveDlOptions({ downloadOptions });
+      assert.deepStrictEqual(actualOptions, expectedDownloadOptions);
+    });
+  });
+
+  describe('#writeErrorLog', function () {
+    let logFile, logFileBase;
+    const exampleVideoData = {
+      title: 'test',
+      author: 'Test Foo',
+      channelId: 'testFoo-channelid',
+      videoUrl: 'https://example.com',
+      viewers: 0
+    };
+
+    before(function () {
+      logFile = getTempPath(utils.LOGDIR) + '.log';
+      logFileBase = path.basename(logFile);
+    });
+
+    it(testMessages.writeErrorLog[0], async function () {
+      this.slow(700);
+
+      const result = await ytmp3.writeErrorLog(logFileBase, exampleVideoData, { message: 'test' });
+      const stat = await fs.promises.stat(logFile);
+
+      assert.ok(result);
+      assert.ok(fs.existsSync(logFile));
+      assert.notStrictEqual(stat.size, 0);
+      assert.notStrictEqual(fs.readFileSync(logFile, { encoding: 'utf8' }).length, 0);
+    });
+
+    it(testMessages.writeErrorLog[1], async function () {
+      assert.equal(await ytmp3.writeErrorLog(12345, exampleVideoData, { message: 'test' }), false);
+      assert.equal(fs.existsSync(path.join(path.dirname(logFile), '12345')), false);
+    });
+
+    after(function () {
+      // Clean the temporary log file
+      if (fs.existsSync(logFile)) fs.rmSync(logFile);
+    });
+  });
+});


### PR DESCRIPTION
## Description

This PR introduces a new feature to enhance the flexibility of the configuration loading process. The key changes include:

- **New `forceRequire` Parameter:**
  - Added a `forceRequire` option to the `parseConfig` and `importConfig` functions.
  - This parameter allows users to explicitly force the use of `require()` for loading configuration files, even if they have extensions that would typically be handled by `import()`.

- **Improved Windows Compatibility:**
  - Modified the `parseConfig` function to replace backslashes (`\`) with forward slashes (`/`) on Windows systems when using `import()`.
  - This change ensures consistent and reliable path resolution across different environments.

## Why This is Needed

- **Flexibility:** 
  - The `forceRequire` option provides additional control over how configuration files are imported, especially in environments where specific handling is necessary.
  
- **Cross-Platform Support:**
  - The improvements in Windows compatibility ensure that paths are correctly interpreted when using `import()`, reducing potential errors.

## Impact on Existing Code

- **Backward Compatibility:**
  - Existing code that uses `parseConfig` or `importConfig` without the new `forceRequire` parameter will continue to function as before.
  
- **Minor Adjustments:**
  - If the `forceRequire` parameter is used, it will alter the behavior of the configuration loading process, which may require some adjustments in certain scenarios.

## Testing

- Tested the new functionality across different environments, including Windows, to ensure that the `forceRequire` parameter and path adjustments work as intended.