### PR TITLE
fix: Include 'bin' directory in `files` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "files": [
     "index.js",
     "lib/*",
+    "bin/*",
     "LICENSE",
     "README.md",
     "CHANGELOG.md"


### PR DESCRIPTION
## Changes Made

- Add 'bin' directory to the 'files' field in package.json to ensure it is included in the published package.
- Fixes an issue in the previous release where the 'bin' directory was missing, leading to problems with command execution.

Apologies for any inconvenience caused by this oversight. This fix ensures the necessary binaries are properly packaged and available for use.
