### PR TITLE
docs: Fix mismatched link syntax for `fluent-ffmpeg`

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ This project utilizes the following libraries and APIs:
 
 - **(Outdated)** [`ytdl-core`] - Yet another YouTube downloading module. Written with only Javascript and a node-friendly streaming interface.
 - [`@distube/ytdl-core`] - DisTube fork of `ytdl-core`. This fork is dedicated to fixing bugs and adding features that are not merged into the original repo as soon as possible.
-- [`fluent-ffmpeg`] - A library that fluents `ffmpeg` command-line usage, easy to use Node.js module.
+- [`fluent-ffmpeg`][fluent-ffmpeg] - A library that fluents `ffmpeg` command-line usage, easy to use Node.js module.
 
 Special thanks to the authors and contributors of these libraries for their valuable work.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ytmp3-js",
-  "version": "1.1.2",
+  "version": "1.2.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ytmp3-js",
-      "version": "1.1.2",
+      "version": "1.2.0-beta",
       "license": "MIT",
       "dependencies": {
         "@distube/ytdl-core": "^4.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ytmp3-js",
-  "version": "1.1.2",
+  "version": "1.2.0-beta",
   "title": "YTMP3",
   "description": "A Node.js library offers an easy and uncomplicated method for downloading YouTube audio",
   "main": "index.js",


### PR DESCRIPTION
## Overview

This pull request corrects a mismatched link syntax in the README, ensuring consistency and functionality of reference links.

## Changes Made

- Fixed the link syntax for `fluent-ffmpeg` to match the correct Markdown link format.
- Updated the link from `- [\`fluent-ffmpeg\`]` to `- [\`fluent-ffmpeg\`][fluent-ffmpeg]` for proper reference functionality.

## Summary

This change enhances the readability and usability of the documentation by maintaining functional and consistent link formatting in the README.
