### PR TITLE
fix: Enhance thumbnail retriever to support author thumbnails

### DIFF
--- a/lib/utils/format-utils.js
+++ b/lib/utils/format-utils.js
@@ -437,7 +437,8 @@ function getAuthorThumbnails(videoDetails, sort=true) {
     });
   }
   const authorThumbnails = TypeUtils.isPlainObject(videoDetails.author)
-    ? videoDetails.authorThumbnails
+      && Array.isArray(videoDetails.author.thumbnails)
+    ? videoDetails.author.thumbnails
     : [];
   return (!sort) ? authorThumbnails : sortThumbnailsByResolution(authorThumbnails);
 }
@@ -467,8 +468,8 @@ function getVideoThumbnails(videoDetails, sort=true) {
       expectedType: TypeUtils.getType({})
     });
   }
-  const videoThumbnails = TypeUtils.isPlainObject(videoDetails.videoThumbnails)
-    ? videoDetails.videoThumbnails
+  const videoThumbnails = Array.isArray(videoDetails.thumbnails)
+    ? videoDetails.thumbnails
     : [];
   return (!sort) ? videoThumbnails : sortThumbnailsByResolution(videoThumbnails);
 }
@@ -546,6 +547,7 @@ function getThumbnailByResolution(thumbnails, resolutionType) {
 
   // Get the sorted thumbnails for easier processing
   const sortedThumbnails = sortThumbnailsByResolution(thumbnails);
+  let thumbnail = null;
 
   // Mapping of resolution keys to thumbnail identifiers
   const resolutionMapping = {
@@ -559,15 +561,27 @@ function getThumbnailByResolution(thumbnails, resolutionType) {
   const targetKeys = resolutionMapping[resolutionType];
   if (Array.isArray(targetKeys)) {
     for (const key of targetKeys) {
-      const thumb = sortedThumbnails.find((thumb) => thumb.url.includes(key));
-      if (thumb) return thumb;
+      if (!thumbnail) {
+        thumbnail = sortedThumbnails.find((thumb) => thumb.url.includes(key));
+      }
     }
-    return null;  // If no fallback available, return null
+  }
+  // Standard resolution lookup
+  thumbnail = thumbnail
+    || sortedThumbnails.find((thumb) => thumb.url.includes(targetKeys));
+
+  // If the thumbnail is still not found, handle the case where the thumbnail is an author thumbnail
+  if (!thumbnail &&
+    Object.values(sortedThumbnails).some(t => t.width === t.height
+      || /=s[0-9]+(x[0-9]+)?/.test(t.url))
+  ) {
+    // The author thumbnail has a square resolution and may contain size parameters in the URL
+    if (resolutionType === 'max') resolutionType = 'high';  // Change the resolution type to 'high'
+    const resolutionIndex = { low: 0, medium: 1, high: 2 };
+    thumbnail = sortedThumbnails[resolutionIndex[resolutionType]] || null;
   }
 
-  // Standard resolution lookup
-  return sortedThumbnails.find((thumb) =>
-    thumb.url.includes(resolutionMapping[resolutionType])) || null;
+  return thumbnail || null;
 }
 FormatUtils.getThumbnailByResolution = getThumbnailByResolution;
 


### PR DESCRIPTION
## Overview

This pull request addresses issues with the thumbnail retriever functions by adding support for author thumbnails, which have a different structure compared to video thumbnails. The changes enhance the logic to correctly identify and retrieve thumbnails for both video and author entities, ensuring broader compatibility and improved functionality.

## Changes Made
### `getAuthorThumbnails`
  - Now retrieves `thumbnails` from the `author` object if the property exists and is an array.

### `getVideoThumbnails`
  - Adjusted to access `thumbnails` directly from video details.

### `getThumbnailByResolution`
  - Improved the resolution-matching logic by introducing a fallback mechanism for author thumbnails.
  - Recognizes author thumbnails by their distinct attributes (e.g., square resolutions or size parameters in URLs).
  - Refined resolution fallback, setting `'high'` as the default when `'max'` is unavailable.
  - Added conditional logic to handle edge cases where thumbnail dimensions or identifiers differ.

## Impact
- Fixes errors when attempting to retrieve thumbnails from authors.
- Ensures compatibility with both video and author thumbnail structures.
- Improves robustness of thumbnail resolution matching and fallback handling.
- Guarantees a more consistent and reliable API for retrieving thumbnails.

## Summary
This PR resolves inconsistencies in thumbnail retrieval by enhancing the retriever logic for both video and author thumbnails. It introduces targeted fixes and fallback mechanisms to handle edge cases, ensuring the library provides accurate and reliable thumbnails across different use cases.

Related changes: #84