### PR TITLE
[npm]: Bump @distube/ytdl-core to from 4.13.5 to 4.15.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0-beta",
       "license": "MIT",
       "dependencies": {
-        "@distube/ytdl-core": "^4.13.5",
+        "@distube/ytdl-core": "^4.15.9",
         "@mitsuki31/temppath": "^0.5.0",
         "argparse": "^2.0.1",
         "fluent-ffmpeg": "^2.1.3",
@@ -405,11 +405,12 @@
       }
     },
     "node_modules/@distube/ytdl-core": {
-      "version": "4.14.4",
-      "resolved": "https://registry.npmjs.org/@distube/ytdl-core/-/ytdl-core-4.14.4.tgz",
-      "integrity": "sha512-dHb4GW3qATIjRsS6VIhm3Pop7FdUcDFhsnyQlsPeXW7UhTPuNS0BmraKiTpFbpp0Ky+rxBQjJBfPRFsM+dT1fg==",
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/@distube/ytdl-core/-/ytdl-core-4.15.9.tgz",
+      "integrity": "sha512-8rFL1NAMsYz4t7Ryaz09Ld7VgoBurGB0KECG8BpTR2vikN0gD1VVusdfZqTYK/gp7uj/TbTJBa85oMCiVXvxcA==",
       "dependencies": {
-        "http-cookie-agent": "^6.0.5",
+        "http-cookie-agent": "^6.0.8",
+        "https-proxy-agent": "^7.0.6",
         "m3u8stream": "^0.8.6",
         "miniget": "^4.2.3",
         "sax": "^1.4.1",
@@ -533,6 +534,14 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@humanfs/core": {
@@ -837,12 +846,9 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "engines": {
         "node": ">= 14"
       }
@@ -1910,11 +1916,11 @@
       "dev": true
     },
     "node_modules/http-cookie-agent": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-6.0.5.tgz",
-      "integrity": "sha512-sfZ8fDgDP3B1YB+teqSnAK1aPgBu8reUUGxSsndP2XnYN6cM29EURXWXZqQQiaRdor3B4QjpkUNfv21syaO4DA==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-6.0.8.tgz",
+      "integrity": "sha512-qnYh3yLSr2jBsTYkw11elq+T361uKAJaZ2dR4cfYZChw1dt9uL5t3zSUwehoqqVb4oldk1BpkXKm2oat8zV+oA==",
       "dependencies": {
-        "agent-base": "^7.1.1"
+        "agent-base": "^7.1.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1923,13 +1929,25 @@
         "url": "https://github.com/sponsors/3846masa"
       },
       "peerDependencies": {
-        "tough-cookie": "^4.0.0",
+        "tough-cookie": "^4.0.0 || ^5.0.0",
         "undici": "^5.11.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
         "undici": {
           "optional": true
         }
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ignore": {
@@ -3121,9 +3139,15 @@
       }
     },
     "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3565,11 +3589,14 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.2.tgz",
-      "integrity": "sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==",
+      "version": "5.28.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
       "engines": {
-        "node": ">=18.17"
+        "node": ">=14.0"
       }
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@distube/ytdl-core": "^4.13.5",
+    "@distube/ytdl-core": "^4.15.9",
     "@mitsuki31/temppath": "^0.5.0",
     "argparse": "^2.0.1",
     "fluent-ffmpeg": "^2.1.3",


### PR DESCRIPTION
## Manual Update Dependencies

Fixes **403** error while downloading YouTube audio, see the resolution [@distube/ytdl-core#163](https://github.com/distubejs/ytdl-core/pull/163).

View the release on npm: [**@distube/ytdl-core@4.15.9**](https://www.npmjs.com/package/@distube/ytdl-core/v/4.15.9)

---

This change might be unnecessary, because users can do reinstall `ytmp3-js` package and the dependencies will automatically update by `npm`.

```bash
npm rm -g ytmp3-js && npm i -g ytmp3-js
```

## Testing

The changes were tested and successfully ran without any 403 errors.
