### PR TITLE
feat(cache): Add force creation option for overwriting cache

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -296,6 +296,10 @@ class CacheZLib {
  * and retrieve the cached video information. The cache is stored in a JSON file compressed using zlib and
  * encoded in binary format.
  *
+ * If the `cacheOptions.force` is set to `true`, the existing cache with similar ID as video ID from provided
+ * video information object will be overwritten with the specified video information object and all cache properties
+ * will be updated.
+ *
  * Written cache files are using the structure of the {@link VideoInfoCacheObject} type.
  *
  * @class
@@ -311,6 +315,9 @@ class VInfoCache {
    *                                           it will be treated as the path to the cache directory.
    * @param {string} [cacheOptions.cacheDir] - The path to the cache directory, defaults to
    *                                            {@link module:cache~VINFO_CACHE_PATH `VINFO_CACHE_PATH`} if not provided.
+   * @param {boolean} [cacheOptions.force] - If set to `true`, the function will forcily creates the cache file even the
+   *                                         cache file for current video ID already exist and overwrite with the specified
+   *                                         video information. This also makes the `createdDate` cache property to be updated.
    *
    * @returns {Promise.<string>} The path to the cached video information.
    *
@@ -344,8 +351,8 @@ class VInfoCache {
       videoId
     );
 
-    // Check if the cache file already exists
-    if (fs.existsSync(cachePath)) return cachePath;
+    // Check if the cache file already exists and `force` option is falsy
+    if (fs.existsSync(cachePath) && !cacheOptions.force) return cachePath;
     await createDirIfNotExist(path.dirname(cachePath));
 
     vInfo = Object.assign({}, {

--- a/test/unittest/cache.spec.mjs
+++ b/test/unittest/cache.spec.mjs
@@ -39,7 +39,8 @@ describe('module:cache', function () {
       'should able to create a simple human-readable string of the cache object',
       'should validate cache object when cacheOptions.validate is true',
       'should delete a stored cache with the given ID',
-      'should return false if the cache deletion is unsuccessful due to non-existent cache'
+      'should return false if the cache deletion is unsuccessful due to non-existent cache',
+      'should able to overwrite the existing cache file if `cacheOptions.force` enabled'
     ]
   };
 
@@ -222,6 +223,28 @@ describe('module:cache', function () {
           cacheDir: tempCacheDir
         }), false);
       });
+    });
+
+    it(testMessages.VInfoCache[12], async function () {
+      // Get the cache before update
+      const cache = await VInfoCache.getCache(testVideoId, {
+        cacheDir: tempCacheDir
+      });
+
+      // Update the cache file
+      await VInfoCache.createCache(testVideoInfo, {
+        cacheDir: tempCacheDir,
+        force: true  // enable the force creation (e.g., overwrite)
+      });
+      // Get the updated version of cache
+      const cacheUpdated = await VInfoCache.getCache(testVideoId, {
+        cacheDir: tempCacheDir
+      });
+
+      // The ID will still be the same
+      assert.strictEqual(cache.id, cacheUpdated.id);
+      // ... but not for the `createdDate` timestamp
+      assert.notStrictEqual(cache.createdDate, cacheUpdated.createdDate);
     });
   });
 


### PR DESCRIPTION
## Overview

This pull request introduces the ability to force the creation of a cache even when an entry with the same video ID already exists. This feature ensures that developers or later implementations can overwrite outdated or incorrect cache objects with new video information, keeping the cache accurate and up to date.

## Changes Made

### Add New Option to Force Cache Creation

- Introduced the `cacheOptions.force` parameter in the `VInfoCache.createCache` function to enable forced creation and overwriting of an existing cache with the same video ID.
- Ensures that overwriting updates the cache's properties, including the `createdDate` value.
- Updated the API documentation to reflect the new `force` option.

### Add Test Case for Cache Overwrite Ability

- Added a test case to validate that the `cacheOptions.force` option successfully overwrites existing cache entries.
- Ensured the test verifies that the `createdDate` property is updated when an overwrite occurs.

## Updated Implementation

**`createCache`**

```ts
class VInfoCache {
  // ...

  static function createCache(
    vInfo: ytdl.videoInfo,
    cacheOptions?: { cacheDir?: string, force?: boolean } | string
  ): Promise<string>
}
```

## Impact

- Provides flexibility for developers to maintain accurate cache entries by forcing the creation of a cache.
- Supports potential future development scenarios that require cache entries to be refreshed or corrected programmatically.
- Prevents reliance on manual cache deletion before overwriting, streamlining workflows for developers.

## Summary

This feature introduces the `cacheOptions.force` option to `VInfoCache.createCache`, allowing cache overwriting when necessary. Unit tests and API documentation updates have been included to ensure robustness and clarity.
