### PR TITLE
fix(cache): Adjust return value when no caches are found

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -498,7 +498,8 @@ class VInfoCache {
    *
    * @returns {Promise.<Array.<ExtractedVideoInfoCacheObject> | string>}
    *          A promise that resolves to an array of cache contents, a cache formatted into a simple human-readable string
-   *          if the `cacheOptions.humanReadable` option is enabled, or an empty array if no caches are found.
+   *          if the `cacheOptions.humanReadable` option is enabled, or an empty array if no caches are found and `cacheOptions.humanReadable`
+   *          option is disabled; otherwise, returns a `null`.
    *
    * @throws {InvalidTypeError} If the cache path is not a string.
    * @throws {CacheValidationError} If the parsed cache object does not meet the expected format or it is invalid.
@@ -525,7 +526,10 @@ class VInfoCache {
       match: new RegExp(`[a-zA-Z0-9_-]{${URLUtils.MAX_ID_LENGTH}}$`),
       absolute: true
     });
-    if (!cacheList || !cacheList?.length) return [];  // Return early
+    if (!cacheList || !cacheList?.length) {
+      // Return an array only if the `humanReadable` option is disabled
+      return !cacheOptions.humanReadable ? [] : null;  // Return early
+    }
 
     if (cacheOptions.humanReadable) {
       let cacheStr = '';

--- a/test/unittest/cache.spec.mjs
+++ b/test/unittest/cache.spec.mjs
@@ -40,7 +40,8 @@ describe('module:cache', function () {
       'should validate cache object when cacheOptions.validate is true',
       'should delete a stored cache with the given ID',
       'should return false if the cache deletion is unsuccessful due to non-existent cache',
-      'should able to overwrite the existing cache file if `cacheOptions.force` enabled'
+      'should able to overwrite the existing cache file if `cacheOptions.force` enabled',
+      'should return an empty array or `null` depending on `humanReadable` option when no caches found'
     ]
   };
 
@@ -245,6 +246,16 @@ describe('module:cache', function () {
       assert.strictEqual(cache.id, cacheUpdated.id);
       // ... but not for the `createdDate` timestamp
       assert.notStrictEqual(cache.createdDate, cacheUpdated.createdDate);
+    });
+
+    it(testMessages.VInfoCache[13], async function () {
+      const cacheDir = getTempPath(tempCacheDir);
+      const allCacheList = await VInfoCache.getAllCaches({ cacheDir });
+      const allCacheStr = await VInfoCache.getAllCaches({ cacheDir, humanReadable: true });
+
+      assert.ok(Array.isArray(allCacheList));
+      assert.deepStrictEqual(allCacheList, []);
+      assert.strictEqual(allCacheStr, null);
     });
   });
 


### PR DESCRIPTION
## Overview

This pull request adjusts the behavior of the `getAllCaches` function when no caches are found, ensuring consistent and intuitive return values depending on the context of usage.

## Changes Made

- Refactored the `getAllCaches` function to return:
  - An empty array (`[]`) when the `humanReadable` option is **disabled**.
  - A `null` value when the `humanReadable` option is **enabled**.

## Example Cases

Call `getAllCaches` function with `humanReadable` set to `false`:

```js
// ...

// Now the returned value will never `null`
const allCaches = await VInfoCache.getAllCaches({ humanReadable: false });
console.log(allCaches);  // []
```

---

Call `getAllCaches` function with `humanReadable` set to `true`:

```js
// ...

const allCachesStr = await VInfoCache.getAllCaches({ humanReadable: true });
console.log(allCachesStr);  // null
```

## Impact

- Provides clearer semantics for scenarios where no caches are found:
  - Developers can now distinguish between an absence of caches (`null`) when expecting human-readable output versus an empty result set (`[]`) for standard usage.
- Prevents potential confusion or misinterpretation of the return values when using the `getAllCaches` function.

## Summary

The return logic of the `getAllCaches` function has been improved to better align with its intended behavior, offering more predictable and meaningful responses based on the `humanReadable` option. This change enhances usability and prepares the API for more diverse use cases.
