### PR TITLE
chore(eslint): Allow escaping single quotes

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -69,7 +69,7 @@ module.exports = [
         }
       }],
       'linebreak-style': [ 'warn', 'unix' ],
-      quotes: [ 'warn', 'single', { avoidEscape: false } ],
+      quotes: [ 'warn', 'single', { avoidEscape: true } ],
       semi: [ 'error', 'always' ],
       camelcase: [ 'error', { properties: 'always' } ],
       curly: [ 'error', 'multi-line', 'consistent' ],


### PR DESCRIPTION
Updated the `eslint.config.js` file to allow escaping single quotes by setting the `avoidEscape` to `true`.