### PR TITLE
ci: Add FFmpeg artifact workflow & improve `irltest`

### DIFF
--- a/.github/workflows/ffmpeg-artifact.yml
+++ b/.github/workflows/ffmpeg-artifact.yml
@@ -1,0 +1,86 @@
+name: FFmpeg Artifact
+
+on:
+  schedule:
+    - cron: '0 */3 * * *'  # Run every 3 hours in a day
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: FFmpeg version
+        default: latest
+        required: false
+      arch:
+        type: string
+        description: FFmpeg architecture
+        default: x64
+        required: false
+
+env:
+  FFMPEG_VERSION: ${{ inputs.version || 'latest' }}
+  FFMPEG_ARCH: ${{ inputs.arch || 'x64' }}
+
+jobs:
+  ffmpeg-artifact:
+    name: FFmpeg Artifact / ffmpeg-${{ env.FFMPEG_VERSION }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ Ubuntu, Windows, macOS ]
+
+    outputs:
+      ffmpeg-path: ${{ steps.post-dl-artifact.outputs.ffmpeg-path }}
+      ffmpeg-version: ${{ steps.post-dl-artifact.outputs.ffmpeg-version }}
+
+    steps:
+    - name: Fetch FFmpeg from artifact
+      uses: actions/download-artifact@v4
+      id: dl-artifact
+      with:
+        name: ${{ runner.os }}-ffmpeg-${{ env.FFMPEG_VERSION }}-${{ runner.arch }}
+        path: ${{ runner.tool_cache }}/ffmpeg/${{ env.FFMPEG_VERSION }}/${{ runner.arch }}
+      continue-on-error: true
+
+    - name: Fetch FFmpeg from sources
+      if: ${{ steps.dl-artifact.outcome == 'failure' }}
+      uses: FedericoCarboni/setup-ffmpeg@v3
+      id: dl-ffmpeg
+      with:
+        ffmpeg-version: ${{ env.FFMPEG_VERSION }}
+        linking-type: static
+        architecture: ${{ env.FFMPEG_ARCH }}
+
+    - name: Upload FFmpeg to artifact
+      if: ${{ steps.dl-artifact.outcome == 'failure' && steps.dl-ffmpeg.outcome == 'success' }}
+      uses: actions/upload-artifact@v4
+      id: ul-artifact
+      with:
+        name: ${{ runner.os }}-ffmpeg-${{ env.FFMPEG_VERSION }}-${{ runner.arch }}
+        path: ${{ steps.dl-ffmpeg.outputs.ffmpeg-path }}
+        compression-level: 0  # NOTE: Fastest for binary files
+        retention-days: 90
+        if-no-files-found: error
+
+    - name: Post Fetch FFmpeg from artifact
+      id: post-dl-artifact
+      if: ${{ steps.dl-artifact.outcome == 'success' || steps.dl-ffmpeg.outcome == 'success' }}
+      run: |
+        local ffmpegPath=''
+        if [ "${{ steps.dl-artifact.outcome }}" = 'success' ]; then
+          ffmpegPath="${{ steps.dl-artifact.outputs.download-path }}"
+        elif [ "${{ steps.dl-ffmpeg.outcome }}" = 'success' ]; then
+          ffmpegPath="${{ steps.dl-ffmpeg.outputs.ffmpeg-path }}"
+        fi
+        echo "ffmpeg-path=$ffmpegPath" >> "$GITHUB_OUTPUT"
+        echo "ffmpeg-version=$(ffmpeg -version 2>&- | sed -nE 's/^(ffmpeg\s*)?version\s*([0-9.]+)\s*.*/\2/p')" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    - name: Post Upload FFmpeg to artifact
+      id: post-ul-artifact
+      if: ${{ steps.ul-artifact.outcome == 'success' }}
+      run: |
+        echo "Artifact Name: ${{ runner.os }}-ffmpeg-${{ env.FFMPEG_VERSION }}-${{ runner.arch }}"
+        echo "Artifact URL: ${{ steps.ul-artifact.outputs.artifact-url }}"
+        echo "Artifact SHA-256: ${{ steps.ul-artifact.outputs.artifact-digest }}"
+

--- a/.github/workflows/ffmpeg-artifact.yml
+++ b/.github/workflows/ffmpeg-artifact.yml
@@ -43,16 +43,17 @@ jobs:
       continue-on-error: true
 
     - name: Fetch FFmpeg from sources
-      if: ${{ steps.dl-artifact.outcome == 'failure' }}
+      if: steps.dl-artifact.outcome == 'failure'
       uses: FedericoCarboni/setup-ffmpeg@v3
       id: dl-ffmpeg
       with:
         ffmpeg-version: ${{ env.FFMPEG_VERSION }}
-        linking-type: static
         architecture: ${{ env.FFMPEG_ARCH }}
 
     - name: Upload FFmpeg to artifact
-      if: ${{ steps.dl-artifact.outcome == 'failure' && steps.dl-ffmpeg.outcome == 'success' }}
+      if: >-
+        steps.dl-artifact.outcome == 'failure' &&
+        steps.dl-ffmpeg.outcome == 'success'
       uses: actions/upload-artifact@v4
       id: ul-artifact
       with:
@@ -64,7 +65,9 @@ jobs:
 
     - name: Post Fetch FFmpeg from artifact
       id: post-dl-artifact
-      if: ${{ steps.dl-artifact.outcome == 'success' || steps.dl-ffmpeg.outcome == 'success' }}
+      if: >-
+        steps.dl-artifact.outcome == 'success' ||
+        steps.dl-ffmpeg.outcome == 'success'
       run: |
         local ffmpegPath=''
         if [ "${{ steps.dl-artifact.outcome }}" = 'success' ]; then
@@ -72,8 +75,11 @@ jobs:
         elif [ "${{ steps.dl-ffmpeg.outcome }}" = 'success' ]; then
           ffmpegPath="${{ steps.dl-ffmpeg.outputs.ffmpeg-path }}"
         fi
+        local ffmpegVersion=$(ffmpeg -version 2>&- | sed -nE 's/^(ffmpeg\s*)?version\s*([0-9.]+)\s*.*/\2/p')
         echo "ffmpeg-path=$ffmpegPath" >> "$GITHUB_OUTPUT"
-        echo "ffmpeg-version=$(ffmpeg -version 2>&- | sed -nE 's/^(ffmpeg\s*)?version\s*([0-9.]+)\s*.*/\2/p')" >> "$GITHUB_OUTPUT"
+        echo "ffmpeg-version=$ffmpegVersion" >> "$GITHUB_OUTPUT"
+        unset ffmpegPath
+        unset ffmpegVersion
       shell: bash
 
     - name: Post Upload FFmpeg to artifact

--- a/.github/workflows/irltest.yml
+++ b/.github/workflows/irltest.yml
@@ -2,44 +2,73 @@ name: IRL Test
 
 on:
   pull_request:
-    branches: [ "master" ]
+    branches: [ master ]
   schedule:
     - cron: '0 6,18 * * *'  # Every day at 06:00 and 18:00 (twice a day)
   workflow_dispatch:
+  workflow_run:
+    workflows: [ 'FFmpeg Artifact' ]
+    types: [ completed ]
 
 jobs:
   irltest:
-    name: IRL Test (${{ matrix.os }}, Node v${{ matrix.node-ver }})
+    name: IRL Test (${{ matrix.os }}, Node v${{ matrix.node-version }})
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        node-ver: [ 18.x, 20.x ]
+        node-version: [ 18.x, 20.x ]
 
     env:
       FFMPEG_VERSION: 7.0.2
+      NODE_ENV: development
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Setup Node v${{ matrix.node-ver }}
+
+    - name: Setup Node.js / ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-ver }}
-        cache: 'npm'
-    - name: Setup FFmpeg v${{ env.FFMPEG_VERSION }}
+        node-version: ${{ matrix.node-version }}
+        cache: npm
+
+    - name: Verify FFmpeg v${{ env.FFMPEG_VERSION }} installation
+      if: github.event.workflow_run.conclusion == 'success'
+      id: check-ffmpeg
+      run: |
+        local ffmpegPath="${{ runner.tool_cache }}/ffmpeg/${{ env.FFMPEG_VERSION }}/${{ runner.arch }}"
+        if [ -d "$ffmpegPath" ]; then
+          echo "available=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "available=false" >> "$GITHUB_OUTPUT"
+        fi
+      shell: bash
+
+    - name: Fetch FFmpeg v${{ env.FFMPEG_VERSION }} from artifact
+      if: steps.check-ffmpeg.outputs.available == 'false'
+      id: dl-ffmpeg-artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ runner.os }}-ffmpeg-${{ env.FFMPEG_VERSION }}-${{ runner.arch }}
+        path: ${{ runner.tool_cache }}/ffmpeg/${{ env.FFMPEG_VERSION }}/${{ runner.arch }}
+
+    # Run this job only if the FFmpeg artifact is not available
+    - name: Fetch FFmpeg v${{ env.FFMPEG_VERSION }} from sources
+      if: '!cancelled()'
       uses: FedericoCarboni/setup-ffmpeg@v3
-      id: setup-ffmpeg
+      id: dl-ffmpeg
       with:
         ffmpeg-version: ${{ env.FFMPEG_VERSION }}
-        linking-type: static
         architecture: x64
-        github-token: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+
     - name: Clean install the project
       run: npm ci
+
     - name: Run IRL Test
       # FIXME: This test is only specific to conversion tests and should be fixed in the future.
       #        This is due to YouTube restricts download YouTube videos in cloud CI environments
       #        and bots automation, unless handled by proxies.
-      run: npm run test:irl -- -g "\\[CONVERT\\]"
+      run: npm run test:irl:no-dltest

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ downloads.txt
 
 # Generated documentations
 docs/
+!docs/template/

--- a/docs/template/README.md
+++ b/docs/template/README.md
@@ -1,0 +1,55 @@
+## Documentation Landing Page Template
+
+This template provides a simple yet effective way to manage multiple versions of API documentation for this project. It is especially useful for users who need access to older versions while transitioning to newer ones.
+
+### How It Works
+
+- The `index.html` file serves as the **main entry point** to the documentation.
+- The `main.js` script dynamically generates version selection buttons by reading a file named `versions.json` in the current directory.
+- The `versions.json` file contains a list of folder names, each representing a different documentation version.
+
+### `versions.json` Structure
+
+The `versions.json` file follows this format:
+
+```json
+{
+  "versions": [
+    "vX.X.X",
+    "X.X.X",
+    "X.X.X-{build}"
+  ]
+}
+```
+
+**Example:**
+
+```json
+{
+  "versions": [
+    "v1.0.0",
+    "v1.1.0",
+    "v2.0.0",
+    "v2.1.0-beta"
+  ]
+}
+```
+
+Each entry in the `versions` array corresponds to a folder that contains the documentation for that version. When a user selects a version, they are redirected to the respective folder.
+
+### Folder Structure Example
+
+```
+/docs
+  ├── index.html  # Main entry point
+  ├── versions.json  # Stores available documentation versions
+  ├── v1.0.0/  # Documentation for v1.0.0
+  ├── v1.1.0/  # Documentation for v1.1.0
+  ├── v2.0.0/  # Documentation for v2.0.0
+  ├── v2.1.0-beta/  # Documentation for v2.1.0-beta
+  ├── styles.css  # Styles for the landing page
+  └── main.js  # Handles version box generation
+```
+
+This structure ensures that users can seamlessly navigate between different documentation versions.
+

--- a/docs/template/index.html
+++ b/docs/template/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>YTMP3-JS Documentation Entry</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Serif:wght@400;500;700&display=swap" />
+    <link rel="stylesheet" href="main.css">
+  </head>
+  <body>
+    <h2 class="title">YTMP3-JS DOCUMENTATION</h2>
+    <div class="container" id="versionsContainer">
+      <p>Loading documentation versions...</p>
+    </div>
+    <script src="main.js"></script>
+  </body>
+</html>
+

--- a/docs/template/main.css
+++ b/docs/template/main.css
@@ -1,0 +1,59 @@
+html, *::before, *::after {
+  box-sizing: border-box;
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: "Noto Serif", "Segoe UI", sans-serif;
+  margin: 0;
+  padding: 0;
+  height: 100vh;
+  background-color: #d4d4d4;
+  align-items: center;
+}
+
+.title {
+  display: block;
+  font-family: Poppins, sans-serif;
+  font-size: 2.3rem;
+  font-weight: bold;
+  border-color: green;
+  text-align: center;
+  padding-top: 15px;
+  padding-bottom: 25px;
+}
+
+.container {
+  display: flex;
+  gap: 10%;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+}
+
+.version-box {
+  width: 150px;
+  height: 150px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(255,255,255);
+  background: -moz-linear-gradient(145deg, rgba(255,255,255,1) 10%, rgba(219,219,219,1) 65%, rgba(0,84,228,1) 100%);
+  background: -webkit-linear-gradient(145deg, rgba(255,255,255,1) 10%, rgba(219,219,219,1) 65%, rgba(0,84,228,1) 100%);
+  background: linear-gradient(145deg, rgba(255,255,255,1) 10%, rgba(219,219,219,1) 65%, rgba(0,84,228,1) 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#ffffff",endColorstr="#0054e4",GradientType=1);
+  color: black;
+  font-size: 1.35em;
+  font-weight: bold;
+  text-align: center;
+  cursor: pointer;
+  border-radius: 20px;
+  box-shadow: none;
+  transition: transform 0.2s ease-in-out, box-shadow 0.3s ease-in;
+}
+
+.version-box:hover {
+  transform: scale(1.1);
+  box-shadow: 40px -14px #0054e4cc;
+}
+

--- a/docs/template/main.js
+++ b/docs/template/main.js
@@ -1,0 +1,31 @@
+'use strict';
+
+document.addEventListener('DOMContentLoaded', async function () {
+  const container = document.getElementById('versionsContainer');
+
+  try {
+    const response = await fetch('versions.json');
+    const data = await response.json();
+
+    setTimeout(() => {
+      container.innerHTML = ''; // Clear loading message
+
+      data.versions.forEach(version => {
+        const box = document.createElement('div');
+        box.classList.add('version-box');
+        box.id = version;
+        box.innerHTML = version.startsWith('v') ? version : 'v' + version;
+        box.onclick = () => window.location.href = version;
+        container.appendChild(box);
+      });
+
+      if (data.versions.length === 0) {
+        container.innerHTML = '<p>No documentation versions found.</p>';
+      }
+    }, 2 * 1000);
+  } catch (error) {
+    container.innerHTML = '<p>Failed to load versions.</p>';
+    console.error('Error fetching versions:', error);
+  }
+});
+

--- a/jsdoc.config.js
+++ b/jsdoc.config.js
@@ -11,7 +11,7 @@ module.exports = {
   recurseDepth: 2,
   plugins: [ 'plugins/markdown' ],
   source: {
-    include: [ 'lib', 'config' ],
+    include: [ 'lib' ],
     exclude: [ 'docs', 'node_modules', 'config/example' ],
     includePattern: /.+\.[tj]s(doc|x)?$/,
     excludePattern: /(^|\/|\\)_/

--- a/lib/utils/thumb-utils.js
+++ b/lib/utils/thumb-utils.js
@@ -181,7 +181,7 @@ ThumbnailUtils.getAllThumbnails = getAllThumbnails;
  * - `high`: Prioritizes the `maxresdefault` thumbnail if available, otherwise falls back to `sddefault`.
  * - `max`: Corresponds to `maxresdefault` thumbnail if available, otherwise return `null`.
  *
- * @note It is recommended to use `'high'` to have a fallback value in case the `maxresdefault` is unavailable.
+ * **Note:** It is recommended to use `'high'` to have a fallback value in case the `maxresdefault` is unavailable.
  *
  * @param {Array.<ThumbnailObject>} thumbnails - An array of thumbnail objects.
  * @param {'low' | 'medium' | 'high' | 'max'} resolutionType - Desired resolution level type.
@@ -262,7 +262,7 @@ ThumbnailUtils.getThumbnailByResolution = getThumbnailByResolution;
  * - `high`: Prioritizes the `maxresdefault` thumbnail if available, otherwise falls back to `sddefault`.
  * - `max`: Corresponds to `maxresdefault` thumbnail if available, otherwise return `null`.
  *
- * @note It is recommended to use `'high'` to have a fallback value in case the `maxresdefault` is unavailable.
+ * **Note:** It is recommended to use `'high'` to have a fallback value in case the `maxresdefault` is unavailable.
  *
  * @param {Array.<ThumbnailObject>} thumbnails - An array of thumbnail objects.
  * @param {'low' | 'medium' | 'high' | 'max'} [resolutionType] - Desired resolution level type.


### PR DESCRIPTION
## Overview
This PR introduces a new workflow to manage FFmpeg artifacts and improves the integration test workflow to ensure FFmpeg availability and proper environment setup.

## Changes Made

### Added FFmpeg Artifact Workflow (`ffmpeg-artifact.yml`)
- Runs every **3 hours** to check if the FFmpeg artifact exists.
- If missing, it downloads FFmpeg from a pre-built release using [`FedericoCarboni/setup-ffmpeg`](https://github.com/FedericoCarboni/setup-ffmpeg).
- Ensures that FFmpeg binaries are consistently available for dependent workflows.

### Improved Integration Test Workflow (`irltest.yml`)
- Now depends on the `ffmpeg-artifact.yml` workflow to ensure FFmpeg is available.
- Fixed mismatch in matrix property names, ensuring proper execution.
- Added fallback logic to verify and install FFmpeg if necessary.
- Set `NODE_ENV=development` to ensure consistent behavior in tests.

## Summary
This PR enhances CI by adding an **FFmpeg artifact workflow** and improving the **integration test workflow** to be more robust and self-sufficient. The changes ensure that FFmpeg is always available when needed, reducing potential failures due to missing dependencies.
