### PR TITLE
ci: Add FFmpeg artifact workflow & improve `irltest`

### DIFF
--- a/.github/workflows/ffmpeg-artifact.yml
+++ b/.github/workflows/ffmpeg-artifact.yml
@@ -1,0 +1,86 @@
+name: FFmpeg Artifact
+
+on:
+  schedule:
+    - cron: '0 */3 * * *'  # Run every 3 hours in a day
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: FFmpeg version
+        default: latest
+        required: false
+      arch:
+        type: string
+        description: FFmpeg architecture
+        default: x64
+        required: false
+
+env:
+  FFMPEG_VERSION: ${{ inputs.version || 'latest' }}
+  FFMPEG_ARCH: ${{ inputs.arch || 'x64' }}
+
+jobs:
+  ffmpeg-artifact:
+    name: FFmpeg Artifact / ffmpeg-${{ env.FFMPEG_VERSION }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ Ubuntu, Windows, macOS ]
+
+    outputs:
+      ffmpeg-path: ${{ steps.post-dl-artifact.outputs.ffmpeg-path }}
+      ffmpeg-version: ${{ steps.post-dl-artifact.outputs.ffmpeg-version }}
+
+    steps:
+    - name: Fetch FFmpeg from artifact
+      uses: actions/download-artifact@v4
+      id: dl-artifact
+      with:
+        name: ${{ runner.os }}-ffmpeg-${{ env.FFMPEG_VERSION }}-${{ runner.arch }}
+        path: ${{ runner.tool_cache }}/ffmpeg/${{ env.FFMPEG_VERSION }}/${{ runner.arch }}
+      continue-on-error: true
+
+    - name: Fetch FFmpeg from sources
+      if: ${{ steps.dl-artifact.outcome == 'failure' }}
+      uses: FedericoCarboni/setup-ffmpeg@v3
+      id: dl-ffmpeg
+      with:
+        ffmpeg-version: ${{ env.FFMPEG_VERSION }}
+        linking-type: static
+        architecture: ${{ env.FFMPEG_ARCH }}
+
+    - name: Upload FFmpeg to artifact
+      if: ${{ steps.dl-artifact.outcome == 'failure' && steps.dl-ffmpeg.outcome == 'success' }}
+      uses: actions/upload-artifact@v4
+      id: ul-artifact
+      with:
+        name: ${{ runner.os }}-ffmpeg-${{ env.FFMPEG_VERSION }}-${{ runner.arch }}
+        path: ${{ steps.dl-ffmpeg.outputs.ffmpeg-path }}
+        compression-level: 0  # NOTE: Fastest for binary files
+        retention-days: 90
+        if-no-files-found: error
+
+    - name: Post Fetch FFmpeg from artifact
+      id: post-dl-artifact
+      if: ${{ steps.dl-artifact.outcome == 'success' || steps.dl-ffmpeg.outcome == 'success' }}
+      run: |
+        local ffmpegPath=''
+        if [ "${{ steps.dl-artifact.outcome }}" = 'success' ]; then
+          ffmpegPath="${{ steps.dl-artifact.outputs.download-path }}"
+        elif [ "${{ steps.dl-ffmpeg.outcome }}" = 'success' ]; then
+          ffmpegPath="${{ steps.dl-ffmpeg.outputs.ffmpeg-path }}"
+        fi
+        echo "ffmpeg-path=$ffmpegPath" >> "$GITHUB_OUTPUT"
+        echo "ffmpeg-version=$(ffmpeg -version 2>&- | sed -nE 's/^(ffmpeg\s*)?version\s*([0-9.]+)\s*.*/\2/p')" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    - name: Post Upload FFmpeg to artifact
+      id: post-ul-artifact
+      if: ${{ steps.ul-artifact.outcome == 'success' }}
+      run: |
+        echo "Artifact Name: ${{ runner.os }}-ffmpeg-${{ env.FFMPEG_VERSION }}-${{ runner.arch }}"
+        echo "Artifact URL: ${{ steps.ul-artifact.outputs.artifact-url }}"
+        echo "Artifact SHA-256: ${{ steps.ul-artifact.outputs.artifact-digest }}"
+

--- a/.github/workflows/ffmpeg-artifact.yml
+++ b/.github/workflows/ffmpeg-artifact.yml
@@ -43,16 +43,17 @@ jobs:
       continue-on-error: true
 
     - name: Fetch FFmpeg from sources
-      if: ${{ steps.dl-artifact.outcome == 'failure' }}
+      if: steps.dl-artifact.outcome == 'failure'
       uses: FedericoCarboni/setup-ffmpeg@v3
       id: dl-ffmpeg
       with:
         ffmpeg-version: ${{ env.FFMPEG_VERSION }}
-        linking-type: static
         architecture: ${{ env.FFMPEG_ARCH }}
 
     - name: Upload FFmpeg to artifact
-      if: ${{ steps.dl-artifact.outcome == 'failure' && steps.dl-ffmpeg.outcome == 'success' }}
+      if: >-
+        steps.dl-artifact.outcome == 'failure' &&
+        steps.dl-ffmpeg.outcome == 'success'
       uses: actions/upload-artifact@v4
       id: ul-artifact
       with:
@@ -64,7 +65,9 @@ jobs:
 
     - name: Post Fetch FFmpeg from artifact
       id: post-dl-artifact
-      if: ${{ steps.dl-artifact.outcome == 'success' || steps.dl-ffmpeg.outcome == 'success' }}
+      if: >-
+        steps.dl-artifact.outcome == 'success' ||
+        steps.dl-ffmpeg.outcome == 'success'
       run: |
         local ffmpegPath=''
         if [ "${{ steps.dl-artifact.outcome }}" = 'success' ]; then
@@ -72,8 +75,11 @@ jobs:
         elif [ "${{ steps.dl-ffmpeg.outcome }}" = 'success' ]; then
           ffmpegPath="${{ steps.dl-ffmpeg.outputs.ffmpeg-path }}"
         fi
+        local ffmpegVersion=$(ffmpeg -version 2>&- | sed -nE 's/^(ffmpeg\s*)?version\s*([0-9.]+)\s*.*/\2/p')
         echo "ffmpeg-path=$ffmpegPath" >> "$GITHUB_OUTPUT"
-        echo "ffmpeg-version=$(ffmpeg -version 2>&- | sed -nE 's/^(ffmpeg\s*)?version\s*([0-9.]+)\s*.*/\2/p')" >> "$GITHUB_OUTPUT"
+        echo "ffmpeg-version=$ffmpegVersion" >> "$GITHUB_OUTPUT"
+        unset ffmpegPath
+        unset ffmpegVersion
       shell: bash
 
     - name: Post Upload FFmpeg to artifact

--- a/.github/workflows/irltest.yml
+++ b/.github/workflows/irltest.yml
@@ -2,44 +2,73 @@ name: IRL Test
 
 on:
   pull_request:
-    branches: [ "master" ]
+    branches: [ master ]
   schedule:
     - cron: '0 6,18 * * *'  # Every day at 06:00 and 18:00 (twice a day)
   workflow_dispatch:
+  workflow_run:
+    workflows: [ 'FFmpeg Artifact' ]
+    types: [ completed ]
 
 jobs:
   irltest:
-    name: IRL Test (${{ matrix.os }}, Node v${{ matrix.node-ver }})
+    name: IRL Test (${{ matrix.os }}, Node v${{ matrix.node-version }})
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        node-ver: [ 18.x, 20.x ]
+        node-version: [ 18.x, 20.x ]
 
     env:
       FFMPEG_VERSION: 7.0.2
+      NODE_ENV: development
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Setup Node v${{ matrix.node-ver }}
+
+    - name: Setup Node.js / ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-ver }}
-        cache: 'npm'
-    - name: Setup FFmpeg v${{ env.FFMPEG_VERSION }}
+        node-version: ${{ matrix.node-version }}
+        cache: npm
+
+    - name: Verify FFmpeg v${{ env.FFMPEG_VERSION }} installation
+      if: github.event.workflow_run.conclusion == 'success'
+      id: check-ffmpeg
+      run: |
+        local ffmpegPath="${{ runner.tool_cache }}/ffmpeg/${{ env.FFMPEG_VERSION }}/${{ runner.arch }}"
+        if [ -d "$ffmpegPath" ]; then
+          echo "available=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "available=false" >> "$GITHUB_OUTPUT"
+        fi
+      shell: bash
+
+    - name: Fetch FFmpeg v${{ env.FFMPEG_VERSION }} from artifact
+      if: steps.check-ffmpeg.outputs.available == 'false'
+      id: dl-ffmpeg-artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ runner.os }}-ffmpeg-${{ env.FFMPEG_VERSION }}-${{ runner.arch }}
+        path: ${{ runner.tool_cache }}/ffmpeg/${{ env.FFMPEG_VERSION }}/${{ runner.arch }}
+
+    # Run this job only if the FFmpeg artifact is not available
+    - name: Fetch FFmpeg v${{ env.FFMPEG_VERSION }} from sources
+      if: '!cancelled()'
       uses: FedericoCarboni/setup-ffmpeg@v3
-      id: setup-ffmpeg
+      id: dl-ffmpeg
       with:
         ffmpeg-version: ${{ env.FFMPEG_VERSION }}
-        linking-type: static
         architecture: x64
-        github-token: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+
     - name: Clean install the project
       run: npm ci
+
     - name: Run IRL Test
       # FIXME: This test is only specific to conversion tests and should be fixed in the future.
       #        This is due to YouTube restricts download YouTube videos in cloud CI environments
       #        and bots automation, unless handled by proxies.
-      run: npm run test:irl -- -g "\\[CONVERT\\]"
+      run: npm run test:irl:no-dltest


### PR DESCRIPTION
## Overview
This PR introduces a new workflow to manage FFmpeg artifacts and improves the integration test workflow to ensure FFmpeg availability and proper environment setup.

## Changes Made

### Added FFmpeg Artifact Workflow (`ffmpeg-artifact.yml`)
- Runs every **3 hours** to check if the FFmpeg artifact exists.
- If missing, it downloads FFmpeg from a pre-built release using [`FedericoCarboni/setup-ffmpeg`](https://github.com/FedericoCarboni/setup-ffmpeg).
- Ensures that FFmpeg binaries are consistently available for dependent workflows.

### Improved Integration Test Workflow (`irltest.yml`)
- Now depends on the `ffmpeg-artifact.yml` workflow to ensure FFmpeg is available.
- Fixed mismatch in matrix property names, ensuring proper execution.
- Added fallback logic to verify and install FFmpeg if necessary.
- Set `NODE_ENV=development` to ensure consistent behavior in tests.

## Summary
This PR enhances CI by adding an **FFmpeg artifact workflow** and improving the **integration test workflow** to be more robust and self-sufficient. The changes ensure that FFmpeg is always available when needed, reducing potential failures due to missing dependencies.
