### PR TITLE
feat: Add version information to core module

### DIFF
--- a/src/core/ytmp3.ts
+++ b/src/core/ytmp3.ts
@@ -58,6 +58,7 @@ import {
   LogLevel,
   createLoadingBar,
   STUB_CLASSES_DIR,
+  ROOTDIR,
 } from '#/utils';
 import { waitForConnectivity } from '#/utils/connection';
 import { captureStderr, logError, parseParserError, prettyPrintParserError } from '#/utils/diag';
@@ -69,14 +70,49 @@ import { defaultHandler } from './helpers/handler';
 import type DownloadResult from './internal/interfaces/DownloadResult';
 import type AudioConversionResult from './internal/interfaces/AudioConversionResult';
 import { convertAudio } from './audioconv';
+import { type PackageJSON } from './config';
 
 // --- Module-scoped constants
 const defaultLogger = getGlob('logger', isDebugMode() ? createLogger('DEBUG') : DefaultLogger) as Logger;
 const defaultVInfoCache = new VInfoCache(undefined, { debug: isDebugMode() });  // Default video info cache
 const HAS_SETUP = getGlob('ready', false);
 const HAS_CONNECTIVITY = HAS_SETUP ? getGlob('hasConnectivity', false) === true : undefined;
+const pkgJson = ((): PackageJSON | null => {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(ROOTDIR, 'package.json'), 'utf-8'));
+  } catch (err) {
+    if (defaultLogger.levelStr === 'DEBUG' || isDebugMode())
+      defaultLogger.warn(`Failed to load package.json: ${(err as Error).message}`);
+    return null;
+  }
+})();
 let globalInnertubeSession = getGlob('innertube_session', undefined);
 
+/**
+ * The version of **YTMP3-JS**.
+ * @public
+ */
+export const version = pkgJson?.version ?? '0.0.0-dev';
+/**
+ * An object representing the version of **YTMP3-JS** in more descriptive way.
+ *
+ * This object has 3 properties:
+ * - `major`
+ * - `minor`
+ * - `patch`
+ * - `preRelease`
+ *
+ * @public
+ */
+export const version_info = (() => {
+  const versionList = version.split(/[.-]/).filter(Boolean);
+  return {
+    major: parseInt(versionList[0], 10),
+    minor: parseInt(versionList[1], 10),
+    patch: parseInt(versionList[2], 10),
+    preRelease: versionList[3] || 'stable'
+  };
+})();
 
 /**
  * Retrieves video information from YouTube using `Innertube`.


### PR DESCRIPTION
## Overview

This pull request introduces internal version tracking constants within the core module. These constants provide the current version of the **YTMP3-JS** library, both in string and structured object formats, enabling easier access to version metadata within the codebase.

## Changes Made

- Added two new constants for version representation:
  - `version`: A string containing the semantic version, equivalent to the version declared in `package.json` (e.g., `"5.0.0-dev"`).
  - `version_info`: A structured object containing:
    * `major`: The major version number.
    * `minor`: The minor version number.
    * `patch`: The patch version number.
    * `preRelease`: Optional pre-release tag (e.g., `"dev"`).

## Impact

- **Internal Consistency**: Centralized version metadata improves consistency between runtime behavior and published versioning.
- **Developer Utility**: Simplifies access to version information for debugging, CLI tools, logging, or diagnostics without reading directly from `package.json`.
- **Future-Proofing**: Prepares the codebase for future CLI `--version` commands or API metadata exposure.

## Summary

This change adds native version constants to the core module, allowing runtime introspection of the current **YTMP3-JS** version in both string and structured form. It improves clarity and provides a foundation for version-aware features going forward.
