### PR TITLE
fix: Address the audio converter not exposed

### DIFF
--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -1,7 +1,13 @@
 // Core
 export * from '#/core/ytmp3';
-export * as Ffmpeg from '#/core/ffmpeg-cmdp';
+// Core (FFmpeg)
 export { default as FluentFfmpeg, type FfmpegCommandLogger, type FfmpegCommandOptions } from 'fluent-ffmpeg';
+import * as ffmpegCmdp from '#/core/ffmpeg-cmdp';
+import * as audioconv from '#/core/audioconv';
+export const Ffmpeg = {
+  ...audioconv,
+  ...ffmpegCmdp
+};
 // Cache
 import type { Types } from 'youtubei.js';
 /** Re-exported from `youtubei.js` */


### PR DESCRIPTION
Audio converter API live inside `api/main` module and can be used directly from `Ffmpeg` namespace. For instance:

```ts
import { Ffmpeg } from 'ytmp3-js';

Ffmpeg.convertAudio(...);
```

Not only that, `Ffmpeg` namespace also contains some useful utilities to working with audio files.